### PR TITLE
Lower vscode version requirement to 1.105.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@octokit/types": "^16.0.0",
         "@types/mocha": "^10.0.10",
         "@types/node": "^22.19.1",
-        "@types/vscode": "^1.107.0",
+        "@types/vscode": "^1.105.0",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.2.1",
         "esbuild": "0.27.0",
@@ -28,7 +28,7 @@
         "typescript": "^5.7.2"
       },
       "engines": {
-        "vscode": "^1.106.1"
+        "vscode": "^1.105.0"
       }
     },
     "node_modules/@azure/abort-controller": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "publisher": "expert-lsp",
   "license": "Apache-2.0",
   "engines": {
-    "vscode": "^1.107.0"
+    "vscode": "^1.105.0"
   },
   "categories": [
     "Programming Languages",
@@ -229,7 +229,7 @@
     "@octokit/types": "^16.0.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.19.1",
-    "@types/vscode": "^1.107.0",
+    "@types/vscode": "^1.105.0",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.2.1",
     "esbuild": "0.27.0",


### PR DESCRIPTION
On Ubuntu, vscodium is currently on version 1.105.0 on snapcraft and windsurf is on 1.106.0. I believe lowering the version requirement will make the extension more compatible with various vscode forks.