### PR TITLE
fix: ensure only the asset for the current platform is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,6 +199,11 @@
         "command": "expert.server.reindex",
         "category": "Expert",
         "title": "Rebuild code search index"
+      },
+      {
+        "command": "expert.server.checkForUpdates",
+        "category": "Expert",
+        "title": "Check for updates"
       }
     ],
     "configurationDefaults": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import {
 } from "vscode-languageclient/node";
 import * as Commands from "./commands";
 import * as Configuration from "./configuration";
-import { checkAndInstall } from "./installation";
+import { checkAndInstall, checkForUpdates } from "./installation";
 import * as Logger from "./logger";
 
 let client: LanguageClient | undefined;
@@ -28,6 +28,10 @@ export async function activate(context: ExtensionContext): Promise<LanguageClien
 	}
 
 	ensureDirectoryExists(context.globalStorageUri);
+
+	context.subscriptions.push(
+		commands.registerCommand("expert.server.checkForUpdates", () => checkForUpdates(context)),
+	);
 
 	const serverOptions = await getServerStartupOptions(context);
 	const projectDir = Configuration.getProjectDirUri(workspace);

--- a/src/test/vscode-mock.d.mts
+++ b/src/test/vscode-mock.d.mts
@@ -1,5 +1,6 @@
 export const mockConfigValues: { values: Record<string, unknown> };
 export const mockUpdateCalls: { calls: Array<{ key: string; value: unknown; target: number }> };
+export const mockWindowMessages: { errors: unknown[][]; info: unknown[][] };
 export const ConfigurationTarget: { Global: 1; Workspace: 2; WorkspaceFolder: 3 };
 
 interface MockUri {

--- a/src/test/vscode-mock.mjs
+++ b/src/test/vscode-mock.mjs
@@ -63,8 +63,14 @@ export const Uri = {
 };
 
 export const window = {
-	showErrorMessage: () => Promise.resolve(undefined),
-	showInformationMessage: () => Promise.resolve(undefined),
+	showErrorMessage: (...args) => {
+		mockWindowMessages.errors.push(args);
+		return Promise.resolve(undefined);
+	},
+	showInformationMessage: (...args) => {
+		mockWindowMessages.info.push(args);
+		return Promise.resolve(undefined);
+	},
 	createOutputChannel: () => ({
 		append: () => {},
 		appendLine: () => {},
@@ -90,6 +96,9 @@ export const commands = {
 
 // Track update calls for assertions
 export const mockUpdateCalls = { calls: [] };
+
+// Track window message calls for assertions
+export const mockWindowMessages = { errors: [], info: [] };
 
 export const workspace = {
 	getConfiguration: () => {


### PR DESCRIPTION
One user reported this error:

```
2026-02-18 22:47:48.733 [info] Checking for stable updates...
2026-02-18 22:47:48.981 [info] Latest stable release is tagged "v0.1.0-rc.0", published at 2026-02-19T03:27:26Z
2026-02-18 22:47:48.981 [info] Downloading stable release v0.1.0-rc.0...
2026-02-18 22:47:49.134 [error] An unexpected error occurred checking for updates: fetch failed
2026-02-18 22:47:49.134 [info] Expert Language Server: .../globalStorage/expertlsp.expert/expert_linux_amd64 --stdio
2026-02-18 22:47:49.136 [info] Starting Expert in workspace .../project
2026-02-18 22:47:49.137 [info] [Error - 10:47:49 PM] Expert client: couldn't create connection to server.
2026-02-18 22:47:49.137 [info] Launching server using command .../globalStorage/expertlsp.expert/expert_linux_amd64 failed. Error: spawn .../globalStorage/expertlsp.expert/expert_linux_amd64 ENOENT
```
They were running macos, but got a binary for linux. It seems that they had a linux asset stored in the `globalState`'s manifest. Running on macos, the extension tried to download latest expert, fetch failed(network error or github being github) and the cached linux asset was tried as a backup, and failed.

I don't know why a the linux asset was tried, maybe it's synced between machines? maybe an ssh/remote container session? Whatever the case this PR fixes it.

This PR fixes this by:
- ensuring the asset for the current platform is always used(it could be that versions match but the wrong asset name is in the manifest still)
- if the wrong platform is detected and trying to download expert fails, tell the user about it and let them retry
- if github is unreachable but the right platform asset is available locally, just use the old asset as a fallback

Fixes #21 