### PR TITLE
feat: allow github authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ Additionally, the Expert channel in VSCode's Output tab may contain some pertine
 
 The syntax highlighting grammar for HEEx (`~H` sigils and `*.heex` files) is maintained and provided by the [Phoenix Framework extension](https://marketplace.visualstudio.com/items?itemName=phoenixframework.phoenix). While HEEx is quite similar to EEx, it isn't part of Elixir's standard library.
 
+#### I'm getting rate limited by GitHub when the extension tries to download Expert releases
+
+If you are hitting Github's rate limits for unauthenticated users when the extension tries to download Expert releases, you can log in with Github.
+Open the command palette (`Command + Shift + P`), search for "Expert: Sign in with GitHub", and follow the instructions.
+
 ### Support
 
 If you have questions or need help, please refer to one of the following channels:

--- a/package.json
+++ b/package.json
@@ -204,6 +204,18 @@
         "command": "expert.server.checkForUpdates",
         "category": "Expert",
         "title": "Check for updates"
+      },
+      {
+        "command": "expert.github.login",
+        "category": "Expert",
+        "title": "Sign in with GitHub",
+        "icon": "$(github)"
+      },
+      {
+        "command": "expert.github.logout",
+        "category": "Expert",
+        "title": "Sign out from GitHub",
+        "icon": "$(sign-out)"
       }
     ],
     "configurationDefaults": {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,53 @@
+import { AuthenticationSession, authentication, window } from "vscode";
+import * as Logger from "./logger";
+
+const GITHUB_AUTH_PROVIDER_ID = "github";
+const GITHUB_AUTH_SCOPES = ["repo"];
+
+let currentSession: AuthenticationSession | undefined;
+
+export async function initialize(): Promise<void> {
+	try {
+		currentSession = await authentication.getSession(GITHUB_AUTH_PROVIDER_ID, GITHUB_AUTH_SCOPES, {
+			createIfNone: false,
+		});
+		if (currentSession) {
+			Logger.info(`GitHub authentication initialized for ${currentSession.account.label}`);
+		}
+	} catch (error) {
+		Logger.warn(`Failed to initialize GitHub authentication: ${error}`);
+	}
+}
+
+export async function login(): Promise<boolean> {
+	try {
+		currentSession = await authentication.getSession(GITHUB_AUTH_PROVIDER_ID, GITHUB_AUTH_SCOPES, {
+			createIfNone: true,
+		});
+
+		if (currentSession) {
+			window.showInformationMessage(
+				`Successfully signed in to GitHub as ${currentSession.account.label}`,
+			);
+			Logger.info(`GitHub authentication successful for ${currentSession.account.label}`);
+			return true;
+		}
+		return false;
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		window.showErrorMessage(`Failed to sign in to GitHub: ${errorMessage}`);
+		Logger.error(`GitHub authentication failed: ${errorMessage}`);
+		return false;
+	}
+}
+
+export async function logout(): Promise<void> {
+	if (!currentSession) {
+		return;
+	}
+
+	const username = currentSession.account.label;
+	currentSession = undefined;
+	window.showInformationMessage(`Signed out from GitHub (${username})`);
+	Logger.info(`GitHub session cleared for ${username}`);
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,5 @@
 import { ExecuteCommandRequest, type LanguageClient } from "vscode-languageclient/node";
+import * as Auth from "./auth";
 import * as Logger from "./logger";
 
 export function start(client: LanguageClient) {
@@ -35,4 +36,12 @@ export function reindex(client: LanguageClient) {
 		return;
 	}
 	client.sendRequest(ExecuteCommandRequest.type, { command: "Reindex", arguments: [] });
+}
+
+export async function login(): Promise<void> {
+	await Auth.login();
+}
+
+export async function logout(): Promise<void> {
+	await Auth.logout();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import {
 	ServerOptions,
 	StreamInfo,
 } from "vscode-languageclient/node";
+import * as Auth from "./auth";
 import * as Commands from "./commands";
 import * as Configuration from "./configuration";
 import { checkAndInstall, checkForUpdates } from "./installation";
@@ -29,8 +30,12 @@ export async function activate(context: ExtensionContext): Promise<LanguageClien
 
 	ensureDirectoryExists(context.globalStorageUri);
 
+	await Auth.initialize();
+
 	context.subscriptions.push(
 		commands.registerCommand("expert.server.checkForUpdates", () => checkForUpdates(context)),
+		commands.registerCommand("expert.github.login", Commands.login),
+		commands.registerCommand("expert.github.logout", Commands.logout),
 	);
 
 	const serverOptions = await getServerStartupOptions(context);

--- a/src/github.ts
+++ b/src/github.ts
@@ -51,10 +51,18 @@ export const GITHUB_HEADERS = {
 	"X-GitHub-Api-Version": "2022-11-28",
 };
 
-export async function fetchNightlyRelease(): Promise<Release> {
+function getHeaders(authToken?: string): Record<string, string> {
+	const headers: Record<string, string> = { ...GITHUB_HEADERS };
+	if (authToken) {
+		headers.Authorization = `Bearer ${authToken}`;
+	}
+	return headers;
+}
+
+export async function fetchNightlyRelease(authToken?: string): Promise<Release> {
 	const url = "https://api.github.com/repos/elixir-lang/expert/releases/tags/nightly";
 
-	const response: Response = await fetch(url, { headers: GITHUB_HEADERS }).catch((e) => {
+	const response: Response = await fetch(url, { headers: getHeaders(authToken) }).catch((e) => {
 		const errorMessage = e instanceof Error ? e.message : String(e);
 		Logger.error(`Failed to connect to GitHub API at ${url}: ${errorMessage}`);
 		throw new Error(`Failed to connect to GitHub API: ${errorMessage}`);
@@ -80,10 +88,10 @@ export async function fetchNightlyRelease(): Promise<Release> {
 	return nightly;
 }
 
-export async function releases(): Promise<Releases> {
+export async function releases(authToken?: string): Promise<Releases> {
 	const url = "https://api.github.com/repos/elixir-lang/expert/releases";
 
-	const response: Response = await fetch(url, { headers: GITHUB_HEADERS }).catch((e) => {
+	const response: Response = await fetch(url, { headers: getHeaders(authToken) }).catch((e) => {
 		const errorMessage = e instanceof Error ? e.message : String(e);
 		Logger.error(`Failed to connect to GitHub API at ${url}: ${errorMessage}`);
 		throw new Error(`Failed to connect to GitHub API: ${errorMessage}`);
@@ -103,8 +111,8 @@ export async function releases(): Promise<Releases> {
 	return (await response.json()) as Releases;
 }
 
-export async function fetchStableRelease(): Promise<Release | null> {
-	const allReleases = await releases();
+export async function fetchStableRelease(authToken?: string): Promise<Release | null> {
+	const allReleases = await releases(authToken);
 
 	const stableReleases = allReleases.filter((release) => {
 		if (release.draft) {


### PR DESCRIPTION
Adds two commands to log into and log out of Github

If logged in, we'll use authenticated requests to download Expert. This should help if you're hitting Github's rate limits(can happen often during development) or other scenarios where unauthenticated requests are not an option.

This uses VSCode's builtin [authentication api](https://code.visualstudio.com/api/references/vscode-api#authentication).