### PR TITLE
feat: add commands for engine maintenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,14 +208,22 @@
       {
         "command": "expert.github.login",
         "category": "Expert",
-        "title": "Sign in with GitHub",
-        "icon": "$(github)"
+        "title": "Sign in with GitHub"
       },
       {
         "command": "expert.github.logout",
         "category": "Expert",
-        "title": "Sign out from GitHub",
-        "icon": "$(sign-out)"
+        "title": "Sign out from GitHub"
+      },
+      {
+        "command": "expert.engine.list",
+        "category": "Expert",
+        "title": "List engine builds"
+      },
+      {
+        "command": "expert.engine.clean",
+        "category": "Expert",
+        "title": "Clean engine builds"
       }
     ],
     "configurationDefaults": {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,0 +1,193 @@
+import { exec as execCb, spawn } from "child_process";
+import * as vscode from "vscode";
+import { getExpertBinaryPath } from "./extension";
+import * as Logger from "./logger";
+
+function exec(command: string): Promise<{ stdout: string; stderr: string }> {
+	return new Promise((resolve, reject) => {
+		execCb(command, (err, stdout, stderr) => {
+			if (err) {
+				reject(err);
+			} else {
+				resolve({ stdout, stderr });
+			}
+		});
+	});
+}
+
+interface EngineBuild {
+	path: string;
+}
+
+export function parseEngineList(output: string): EngineBuild[] {
+	return output
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.startsWith("/") || /^[A-Za-z]:\\/.test(line))
+		.map((line) => ({ path: line }));
+}
+
+export async function listEngines(): Promise<void> {
+	const binaryPath = await getExpertBinaryPath();
+	if (!binaryPath) {
+		vscode.window.showErrorMessage(
+			"Expert binary not found. Please ensure the language server is installed.",
+		);
+		return;
+	}
+
+	Logger.info("Listing expert engine builds...");
+
+	let stdout: string;
+	try {
+		({ stdout } = await exec(`"${binaryPath}" engine ls`));
+	} catch (e) {
+		const errorMsg = e instanceof Error ? e.message : String(e);
+		Logger.error(`Failed to list engines: ${errorMsg}`);
+		vscode.window.showErrorMessage(`Failed to list engine builds: ${errorMsg}`);
+		return;
+	}
+
+	const builds = parseEngineList(stdout);
+	if (builds.length === 0) {
+		vscode.window.showInformationMessage("No engine builds found.");
+		return;
+	}
+
+	const items = builds.map((build) => ({
+		label: build.path,
+		path: build.path,
+	}));
+
+	const selection = await vscode.window.showQuickPick(items, {
+		canPickMany: false,
+		placeHolder: `Found ${builds.length} engine build${builds.length === 1 ? "" : "s"} (select to copy path)`,
+		title: "Expert Engine Builds",
+	});
+
+	if (selection) {
+		await vscode.env.clipboard.writeText(selection.path);
+		vscode.window.showInformationMessage(`Copied path to clipboard: ${selection.path}`);
+		Logger.info(`User selected and copied engine path: ${selection.label}`);
+	}
+}
+
+export async function cleanEngines(): Promise<void> {
+	const binaryPath = await getExpertBinaryPath();
+	if (!binaryPath) {
+		vscode.window.showErrorMessage(
+			"Expert binary not found. Please ensure the language server is installed.",
+		);
+		return;
+	}
+
+	Logger.info("Fetching expert engine builds for cleanup...");
+
+	let stdout: string;
+	try {
+		({ stdout } = await exec(`"${binaryPath}" engine ls`));
+	} catch (e) {
+		const errorMsg = e instanceof Error ? e.message : String(e);
+		Logger.error(`Failed to list engines: ${errorMsg}`);
+		vscode.window.showErrorMessage(`Failed to fetch engine builds: ${errorMsg}`);
+		return;
+	}
+
+	const builds = parseEngineList(stdout);
+	if (builds.length === 0) {
+		vscode.window.showInformationMessage("No engine builds found.");
+		return;
+	}
+
+	const items = builds.map((build) => ({
+		label: build.path,
+		path: build.path,
+		picked: false,
+	}));
+
+	const selections = await vscode.window.showQuickPick(items, {
+		canPickMany: true,
+		placeHolder: "Select engine builds to delete (use space to toggle selection)",
+		title: "Clean Expert Engine Builds",
+	});
+
+	if (!selections || selections.length === 0) {
+		Logger.info("No engine builds selected for cleanup.");
+		return;
+	}
+
+	const confirmed = await vscode.window.showWarningMessage(
+		`Delete ${selections.length} engine build${selections.length === 1 ? "" : "s"}?`,
+		{ modal: true },
+		"Delete",
+	);
+
+	if (confirmed !== "Delete") {
+		Logger.info("Engine cleanup cancelled by user.");
+		return;
+	}
+
+	const pathsToDelete = new Set(selections.map((s: { path: string }) => s.path));
+	Logger.info(`Will delete ${pathsToDelete.size} selected engine build(s), skipping others`);
+
+	await runClean(binaryPath, pathsToDelete, selections.length);
+}
+
+function runClean(binaryPath: string, pathsToDelete: Set<string>, count: number): Promise<void> {
+	return new Promise((resolve) => {
+		// Don't pass paths - expert clean ignores args and always prompts for all engines
+		const childProcess = spawn(`"${binaryPath}"`, ["engine", "clean"], {
+			shell: true,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+
+		let buffer = "";
+
+		childProcess.stdout.on("data", (data: Buffer) => {
+			const text = data.toString();
+			buffer += text;
+			Logger.info(`Engine clean: ${text}`);
+
+			const promptMatch = buffer.match(/Delete\s+(.+?)\?\s*\[Yn\]/);
+			if (promptMatch) {
+				const enginePath = promptMatch[1].trim();
+				if (pathsToDelete.has(enginePath)) {
+					Logger.info(`Confirming deletion for: ${enginePath}`);
+					childProcess.stdin.write("Y\n");
+				} else {
+					Logger.info(`Skipping: ${enginePath}`);
+					childProcess.stdin.write("n\n");
+				}
+				buffer = "";
+			}
+		});
+
+		childProcess.stderr.on("data", (data: Buffer) => {
+			Logger.error(`Engine clean error: ${data.toString()}`);
+		});
+
+		childProcess.on("close", (code: number | null) => {
+			childProcess.stdin.end();
+
+			if (code === 0) {
+				Logger.info(`Successfully processed ${count} engine build${count === 1 ? "" : "s"}`);
+				vscode.window.showInformationMessage(
+					`Deleted ${count} engine build${count === 1 ? "" : "s"}.`,
+				);
+			} else {
+				Logger.error(`Engine clean failed with exit code ${code}`);
+				vscode.window.showErrorMessage(
+					"Failed to clean engine builds. Check output channel for details.",
+				);
+			}
+
+			resolve();
+		});
+
+		childProcess.on("error", (err: Error) => {
+			Logger.error(`Failed to spawn engine clean process: ${err.message}`);
+			vscode.window.showErrorMessage(`Failed to start cleanup process: ${err.message}`);
+			resolve();
+		});
+	});
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,17 +9,27 @@ import {
 import * as Auth from "./auth";
 import * as Commands from "./commands";
 import * as Configuration from "./configuration";
-import { checkAndInstall, checkForUpdates } from "./installation";
+import * as Engine from "./engine";
+import { checkAndInstall, checkForUpdates, Manifest } from "./installation";
 import * as Logger from "./logger";
 
 let client: LanguageClient | undefined;
+let extensionContext: ExtensionContext | undefined;
 
 /**
  * Called by VSCode when starting the extension.
  * @param context Extension Context provided by Visual Studio Code.
  */
 export async function activate(context: ExtensionContext): Promise<LanguageClient | undefined> {
+	extensionContext = context;
 	const serverEnabled = Configuration.getServerEnabled();
+
+	ensureDirectoryExists(context.globalStorageUri);
+
+	context.subscriptions.push(
+		commands.registerCommand("expert.engine.list", Engine.listEngines),
+		commands.registerCommand("expert.engine.clean", Engine.cleanEngines),
+	);
 
 	if (serverEnabled === false) {
 		Logger.info(
@@ -27,8 +37,6 @@ export async function activate(context: ExtensionContext): Promise<LanguageClien
 		);
 		return undefined;
 	}
-
-	ensureDirectoryExists(context.globalStorageUri);
 
 	await Auth.initialize();
 
@@ -149,6 +157,7 @@ async function getServerStartupOptions(
 
 	if (typeof releasePathOverride === "string" && releasePathOverride.length > 0) {
 		Logger.info(`starting language server from release override: "${releasePathOverride}".`);
+		setExpertBinaryPath(releasePathOverride);
 		return { command: releasePathOverride, args };
 	}
 
@@ -157,7 +166,42 @@ async function getServerStartupOptions(
 		return undefined;
 	}
 
+	setExpertBinaryPath(languageServerPath);
+
 	Logger.info(`Expert Language Server:\n${languageServerPath} ${args.join(" ")}`);
 
 	return { command: languageServerPath, args };
+}
+
+let cachedExpertBinaryPath: string | null | undefined = undefined;
+
+export async function getExpertBinaryPath(): Promise<string | undefined> {
+	if (cachedExpertBinaryPath !== undefined) {
+		return cachedExpertBinaryPath ?? undefined;
+	}
+
+	const releasePathOverride = Configuration.getReleasePathOverride();
+
+	if (typeof releasePathOverride === "string" && releasePathOverride.length > 0) {
+		cachedExpertBinaryPath = releasePathOverride;
+		return releasePathOverride;
+	}
+
+	if (extensionContext) {
+		const manifest = extensionContext.globalState.get<Manifest>("install_manifest");
+		if (manifest) {
+			const installPath = Uri.joinPath(extensionContext.globalStorageUri, manifest.name);
+			if (fs.existsSync(installPath.fsPath)) {
+				cachedExpertBinaryPath = installPath.fsPath;
+				return installPath.fsPath;
+			}
+		}
+	}
+
+	cachedExpertBinaryPath = null;
+	return undefined;
+}
+
+export function setExpertBinaryPath(path: string | undefined): void {
+	cachedExpertBinaryPath = path ?? null;
 }

--- a/src/test/engine.test.ts
+++ b/src/test/engine.test.ts
@@ -1,0 +1,371 @@
+// biome-ignore-all lint/suspicious/noEmptyBlockStatements: mocks void functions
+import assert from "node:assert";
+import { before, beforeEach, describe, it, type Mock, mock } from "node:test";
+import {
+	mockClipboard,
+	mockQuickPick,
+	mockWarningMessage,
+	mockWindowMessages,
+} from "./vscode-mock.mjs";
+
+interface MockSpawnProcess {
+	stdin: {
+		write: Mock<(data: string) => boolean>;
+		end: Mock<() => void>;
+	};
+	emitStdout: (data: Buffer) => void;
+	emitClose: (code: number | null) => void;
+}
+
+type ExecResponse = { stdout: string; stderr: string } | Error;
+
+let nextExecResponse: ExecResponse = { stdout: "", stderr: "" };
+let lastSpawnProcess: MockSpawnProcess | undefined;
+let binaryPathValue: string | undefined = "/test/expert";
+
+function createMockSpawnResult() {
+	const stdoutHandlers: Array<(data: Buffer) => void> = [];
+	const closeHandlers: Array<(code: number | null) => void> = [];
+
+	const stdinWrite: Mock<(data: string) => boolean> = mock.fn((_data: string) => true);
+	const stdinEnd: Mock<() => void> = mock.fn(() => {});
+
+	const proc = {
+		stdin: { write: stdinWrite, end: stdinEnd },
+		stdout: {
+			on: (_event: string, handler: (data: Buffer) => void) => {
+				stdoutHandlers.push(handler);
+			},
+		},
+		stderr: {
+			on: (_event: string, _handler: (data: Buffer) => void) => {},
+		},
+		on: (event: string, handler: (arg: number | null | Error) => void) => {
+			if (event === "close") {
+				closeHandlers.push(handler as (code: number | null) => void);
+			}
+		},
+		emitStdout: (data: Buffer) => stdoutHandlers.forEach((h) => h(data)),
+		emitClose: (code: number | null) => closeHandlers.forEach((h) => h(code)),
+	};
+
+	lastSpawnProcess = proc;
+	return proc;
+}
+
+describe("Engine management", () => {
+	let Engine: typeof import("../engine");
+
+	before(async () => {
+		mock.module("child_process", {
+			namedExports: {
+				exec: (
+					_command: string,
+					callback: (err: Error | null, stdout: string, stderr: string) => void,
+				) => {
+					const res = nextExecResponse;
+					nextExecResponse = { stdout: "", stderr: "" };
+					if (res instanceof Error) {
+						callback(res, "", res.message);
+					} else {
+						callback(null, res.stdout, res.stderr);
+					}
+				},
+				spawn: (_command: string, _args: string[], _options: unknown) => createMockSpawnResult(),
+			},
+		});
+
+		mock.module("../extension", {
+			namedExports: {
+				getExpertBinaryPath: async () => binaryPathValue,
+			},
+		});
+
+		mock.module("../logger", {
+			namedExports: {
+				info: () => {},
+				error: () => {},
+				warn: () => {},
+				outputChannel: () => ({
+					append: () => {},
+					appendLine: () => {},
+					clear: () => {},
+					dispose: () => {},
+					hide: () => {},
+					show: () => {},
+				}),
+			},
+		});
+
+		Engine = await import("../engine");
+	});
+
+	beforeEach(() => {
+		nextExecResponse = { stdout: "", stderr: "" };
+		lastSpawnProcess = undefined;
+		binaryPathValue = "/test/expert";
+		mockQuickPick.nextValue = undefined;
+		mockQuickPick.calls.length = 0;
+		mockWarningMessage.nextResponse = "Delete";
+		mockClipboard.writes.length = 0;
+		mockWindowMessages.errors.length = 0;
+		mockWindowMessages.info.length = 0;
+	});
+
+	describe("parseEngineList", () => {
+		it("parses simple engine paths", () => {
+			const output = [
+				"/Users/dorgan/Library/Application Support/Expert/0.1.0/ex-1.19.1-erl-16.1.2",
+				"/Users/dorgan/Library/Application Support/Expert/0.1.0-rc.0/elixir-1.18.4-erts-15.2.7.4",
+			].join("\n");
+
+			const builds = Engine.parseEngineList(output);
+
+			assert.strictEqual(builds.length, 2);
+			assert.strictEqual(
+				builds[0].path,
+				"/Users/dorgan/Library/Application Support/Expert/0.1.0/ex-1.19.1-erl-16.1.2",
+			);
+			assert.strictEqual(
+				builds[1].path,
+				"/Users/dorgan/Library/Application Support/Expert/0.1.0-rc.0/elixir-1.18.4-erts-15.2.7.4",
+			);
+		});
+
+		it("handles empty output", () => {
+			assert.strictEqual(Engine.parseEngineList("").length, 0);
+		});
+
+		it("handles output with only whitespace", () => {
+			assert.strictEqual(Engine.parseEngineList("   \n\t\n   ").length, 0);
+		});
+
+		it("handles Windows paths", () => {
+			const output = [
+				"C:\\Users\\test\\AppData\\Local\\Expert\\0.1.0\\ex-1.19.1-erl-16.1.2",
+				"C:\\Users\\test\\AppData\\Local\\Expert\\0.1.0-rc.0\\elixir-1.18.4-erts-15.2.7.4",
+			].join("\n");
+
+			const builds = Engine.parseEngineList(output);
+
+			assert.strictEqual(builds.length, 2);
+			assert.strictEqual(
+				builds[0].path,
+				"C:\\Users\\test\\AppData\\Local\\Expert\\0.1.0\\ex-1.19.1-erl-16.1.2",
+			);
+		});
+
+		it("ignores non-path lines", () => {
+			const output = [
+				"Some header text",
+				"/Users/dorgan/Library/Application Support/Expert/0.1.0/ex-1.19.1-erl-16.1.2",
+				"More text",
+				"/Users/dorgan/Library/Application Support/Expert/0.1.0-rc.0/elixir-1.18.4-erts-15.2.7.4",
+			].join("\n");
+
+			const builds = Engine.parseEngineList(output);
+
+			assert.strictEqual(builds.length, 2);
+			assert.strictEqual(
+				builds[0].path,
+				"/Users/dorgan/Library/Application Support/Expert/0.1.0/ex-1.19.1-erl-16.1.2",
+			);
+			assert.strictEqual(
+				builds[1].path,
+				"/Users/dorgan/Library/Application Support/Expert/0.1.0-rc.0/elixir-1.18.4-erts-15.2.7.4",
+			);
+		});
+	});
+
+	describe("listEngines", () => {
+		it("shows error when binary not found", async () => {
+			binaryPathValue = undefined;
+
+			await Engine.listEngines();
+
+			assert.strictEqual(mockWindowMessages.errors.length, 1);
+			assert.ok((mockWindowMessages.errors[0][0] as string).includes("Expert binary not found"));
+		});
+
+		it("shows no builds message when list is empty", async () => {
+			nextExecResponse = { stdout: "", stderr: "" };
+
+			await Engine.listEngines();
+
+			assert.strictEqual(mockWindowMessages.info.length, 1);
+			assert.ok((mockWindowMessages.info[0][0] as string).includes("No engine builds found"));
+		});
+
+		it("shows builds in quick pick", async () => {
+			const path1 = "/Users/dorgan/Library/Application Support/Expert/0.1.0/ex-1.19.1-erl-16.1.2";
+			const path2 =
+				"/Users/dorgan/Library/Application Support/Expert/0.1.0-rc.0/elixir-1.18.4-erts-15.2.7.4";
+			nextExecResponse = { stdout: [path1, path2].join("\n"), stderr: "" };
+
+			await Engine.listEngines();
+
+			assert.strictEqual(mockQuickPick.calls.length, 1);
+			const items = mockQuickPick.calls[0].items as Array<{ label: string }>;
+			assert.strictEqual(items.length, 2);
+			assert.ok(items[0].label.includes("0.1.0/ex-1.19.1"));
+			assert.ok(items[1].label.includes("0.1.0-rc.0/elixir-1.18.4"));
+		});
+
+		it("copies path to clipboard when user selects a build", async () => {
+			const testPath =
+				"/Users/dorgan/Library/Application Support/Expert/0.1.0/ex-1.19.1-erl-16.1.2";
+			nextExecResponse = { stdout: testPath, stderr: "" };
+			mockQuickPick.nextValue = { path: testPath, label: testPath };
+
+			await Engine.listEngines();
+
+			assert.strictEqual(mockClipboard.writes.length, 1);
+			assert.strictEqual(mockClipboard.writes[0], testPath);
+		});
+
+		it("handles exec errors", async () => {
+			nextExecResponse = new Error("Command failed");
+
+			await Engine.listEngines();
+
+			assert.strictEqual(mockWindowMessages.errors.length, 1);
+			assert.ok(
+				(mockWindowMessages.errors[0][0] as string).includes("Failed to list engine builds"),
+			);
+		});
+	});
+
+	describe("cleanEngines", () => {
+		it("shows error when binary not found", async () => {
+			binaryPathValue = undefined;
+
+			await Engine.cleanEngines();
+
+			assert.strictEqual(mockWindowMessages.errors.length, 1);
+			assert.ok((mockWindowMessages.errors[0][0] as string).includes("Expert binary not found"));
+		});
+
+		it("shows no builds message when list is empty", async () => {
+			nextExecResponse = { stdout: "", stderr: "" };
+
+			await Engine.cleanEngines();
+
+			assert.strictEqual(mockWindowMessages.info.length, 1);
+			assert.ok((mockWindowMessages.info[0][0] as string).includes("No engine builds found"));
+		});
+
+		it("displays builds in multi-select quick pick", async () => {
+			const path1 = "/Users/dorgan/Library/Application Support/Expert/0.1.0/ex-1.19.1-erl-16.1.2";
+			const path2 =
+				"/Users/dorgan/Library/Application Support/Expert/0.1.0-rc.0/elixir-1.18.4-erts-15.2.7.4";
+			nextExecResponse = { stdout: [path1, path2].join("\n"), stderr: "" };
+			mockQuickPick.nextValue = [];
+
+			await Engine.cleanEngines();
+
+			assert.strictEqual(mockQuickPick.calls.length, 1);
+			assert.strictEqual(
+				(mockQuickPick.calls[0].options as { canPickMany: boolean }).canPickMany,
+				true,
+			);
+			assert.strictEqual(mockQuickPick.calls[0].items.length, 2);
+		});
+
+		it("does nothing when user cancels selection", async () => {
+			const path = "/Users/dorgan/Library/Application Support/Expert/0.1.0/ex-1.19.1-erl-16.1.2";
+			nextExecResponse = { stdout: path, stderr: "" };
+			mockQuickPick.nextValue = [];
+
+			await Engine.cleanEngines();
+
+			assert.strictEqual(lastSpawnProcess, undefined);
+		});
+
+		it("does nothing when user rejects confirmation", async () => {
+			const path = "/Users/dorgan/Library/Application Support/Expert/0.1.0/ex-1.19.1-erl-16.1.2";
+			nextExecResponse = { stdout: path, stderr: "" };
+			mockQuickPick.nextValue = [{ path, label: path }];
+			mockWarningMessage.nextResponse = undefined;
+
+			await Engine.cleanEngines();
+
+			assert.strictEqual(lastSpawnProcess, undefined);
+		});
+
+		it("responds Y to prompts for selected engines", async () => {
+			const selectedPath =
+				"/Users/dorgan/Library/Application Support/Expert/0.1.0/ex-1.19.1-erl-16.1.2";
+			const unselectedPath =
+				"/Users/dorgan/Library/Application Support/Expert/0.1.0-rc.0/elixir-1.18.4-erts-15.2.7.4";
+			nextExecResponse = { stdout: [selectedPath, unselectedPath].join("\n"), stderr: "" };
+			mockQuickPick.nextValue = [{ path: selectedPath, label: selectedPath }];
+
+			const cleanPromise = Engine.cleanEngines();
+			await flushAsync();
+
+			const proc = lastSpawnProcess!;
+			proc.emitStdout(Buffer.from(`Delete ${selectedPath}? [Yn]`));
+			proc.emitClose(0);
+			await cleanPromise;
+
+			assert.ok(proc.stdin.write.mock.calls.some((c) => c.arguments[0] === "Y\n"));
+		});
+
+		it("responds n to prompts for unselected engines", async () => {
+			const selectedPath =
+				"/Users/dorgan/Library/Application Support/Expert/0.1.0/ex-1.19.1-erl-16.1.2";
+			const unselectedPath =
+				"/Users/dorgan/Library/Application Support/Expert/0.1.0-rc.0/elixir-1.18.4-erts-15.2.7.4";
+			nextExecResponse = { stdout: [selectedPath, unselectedPath].join("\n"), stderr: "" };
+			mockQuickPick.nextValue = [{ path: selectedPath, label: selectedPath }];
+
+			const cleanPromise = Engine.cleanEngines();
+			await flushAsync();
+
+			const proc = lastSpawnProcess!;
+			proc.emitStdout(Buffer.from(`Delete ${unselectedPath}? [Yn]`));
+			proc.emitClose(0);
+			await cleanPromise;
+
+			assert.ok(proc.stdin.write.mock.calls.some((c) => c.arguments[0] === "n\n"));
+		});
+
+		it("shows success message when clean completes", async () => {
+			const selectedPath =
+				"/Users/dorgan/Library/Application Support/Expert/0.1.0/ex-1.19.1-erl-16.1.2";
+			nextExecResponse = { stdout: selectedPath, stderr: "" };
+			mockQuickPick.nextValue = [{ path: selectedPath, label: selectedPath }];
+
+			const cleanPromise = Engine.cleanEngines();
+			await flushAsync();
+
+			lastSpawnProcess!.emitClose(0);
+			await cleanPromise;
+
+			assert.ok(mockWindowMessages.info.some((m) => (m[0] as string).includes("Deleted")));
+		});
+
+		it("shows error message when clean fails", async () => {
+			const selectedPath =
+				"/Users/dorgan/Library/Application Support/Expert/0.1.0/ex-1.19.1-erl-16.1.2";
+			nextExecResponse = { stdout: selectedPath, stderr: "" };
+			mockQuickPick.nextValue = [{ path: selectedPath, label: selectedPath }];
+
+			const cleanPromise = Engine.cleanEngines();
+			await flushAsync();
+
+			lastSpawnProcess!.emitClose(1);
+			await cleanPromise;
+
+			assert.ok(
+				mockWindowMessages.errors.some((m) =>
+					(m[0] as string).includes("Failed to clean engine builds"),
+				),
+			);
+		});
+	});
+});
+
+function flushAsync(): Promise<void> {
+	return new Promise((resolve) => setImmediate(resolve));
+}

--- a/src/test/vscode-mock.d.mts
+++ b/src/test/vscode-mock.d.mts
@@ -1,6 +1,12 @@
 export const mockConfigValues: { values: Record<string, unknown> };
 export const mockUpdateCalls: { calls: Array<{ key: string; value: unknown; target: number }> };
 export const mockWindowMessages: { errors: unknown[][]; info: unknown[][] };
+export const mockQuickPick: {
+	nextValue: unknown;
+	calls: Array<{ items: unknown[]; options: unknown }>;
+};
+export const mockWarningMessage: { nextResponse: string | undefined };
+export const mockClipboard: { writes: string[] };
 export const ConfigurationTarget: { Global: 1; Workspace: 2; WorkspaceFolder: 3 };
 
 interface MockUri {

--- a/src/test/vscode-mock.mjs
+++ b/src/test/vscode-mock.mjs
@@ -1,5 +1,4 @@
 // biome-ignore-all lint/suspicious/noEmptyBlockStatements: mocks void functions
-// biome-ignore-all lint/suspicious/noExplicitAny: mocks as any
 
 // Mock vscode module for tests
 import path from "node:path";
@@ -71,6 +70,13 @@ export const window = {
 		mockWindowMessages.info.push(args);
 		return Promise.resolve(undefined);
 	},
+	showWarningMessage: () => Promise.resolve(mockWarningMessage.nextResponse),
+	showQuickPick: async (items, options) => {
+		mockQuickPick.calls.push({ items, options });
+		const result = mockQuickPick.nextValue;
+		mockQuickPick.nextValue = undefined;
+		return result;
+	},
 	createOutputChannel: () => ({
 		append: () => {},
 		appendLine: () => {},
@@ -86,6 +92,18 @@ export const window = {
 	}),
 };
 
+export const env = {
+	clipboard: {
+		writeText: async (text) => {
+			mockClipboard.writes.push(text);
+		},
+	},
+};
+
+export const authentication = {
+	getSession: async () => undefined,
+};
+
 export const l10n = {
 	t: (message) => message,
 };
@@ -99,6 +117,20 @@ export const mockUpdateCalls = { calls: [] };
 
 // Track window message calls for assertions
 export const mockWindowMessages = { errors: [], info: [] };
+
+// Control state for interactive window mocks
+export const mockQuickPick = {
+	nextValue: undefined,
+	calls: [],
+};
+
+export const mockWarningMessage = {
+	nextResponse: "Delete",
+};
+
+export const mockClipboard = {
+	writes: [],
+};
 
 export const workspace = {
 	getConfiguration: () => {


### PR DESCRIPTION
We're often asking users to clean the engine builds when debugging issues, this PR adds a command to do that from VSCode itself
<img width="611" height="163" alt="Screenshot 2026-02-23 at 3 12 43 PM" src="https://github.com/user-attachments/assets/e2b53724-2dc2-45d9-8aaa-cafb6d44294f" />

I'm wondering if we want to change Expert to somehow take the path to an engine to be removed(or just do the rm -rf from the extension, though that could lead to behavior deviations in the future), for now the implementation just calls `expert engine clean` and interactively says Y or N to each prompt based on the user selection