### PR TITLE
fix: use platform-specific install manifest

### DIFF
--- a/src/installation.ts
+++ b/src/installation.ts
@@ -86,10 +86,7 @@ export async function checkAndInstall(
 	}
 }
 
-function manifestAssetPath(
-	context: ExtensionContext,
-	manifest: Manifest
-): string {
+function manifestAssetPath(context: ExtensionContext, manifest: Manifest): string {
 	return Uri.joinPath(context.globalStorageUri, manifest.name).fsPath;
 }
 
@@ -408,10 +405,7 @@ export async function checkForUpdates(context: ExtensionContext): Promise<string
 	return result;
 }
 
-function showFetchFailedNotification(
-	context: ExtensionContext,
-	attemptCount: number,
-) {
+function showFetchFailedNotification(context: ExtensionContext, attemptCount: number) {
 	const attempt = attemptCount > 0 ? ` (Attempt #${attemptCount + 1})` : "";
 
 	const message = `Failed to fetch Expert release${attempt}.`;

--- a/src/test/installation.test.ts
+++ b/src/test/installation.test.ts
@@ -7,8 +7,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, before, beforeEach, describe, it } from "node:test";
 import nock from "nock";
-import { type Manifest, getManifestKey } from "../installation";
-import { getExpectedAssetName, getPlatformInfo } from "../platform";
+import { getManifestKey, type Manifest } from "../installation";
+import { getExpectedAssetName } from "../platform";
 import * as GithubFixture from "./fixtures/github-fixture";
 import { mockConfigValues, mockWindowMessages } from "./vscode-mock.mjs";
 


### PR DESCRIPTION
Hi, everybody! First, thank you all so much for your work on an official Elixir language server. I ran into an issue trying to get the extension working under Dev Containers and I think I have a fix.

To be clear, everything works great in a Dev Container if you are only using Dev Containers and you setup you project with a volume mount like the following **before** you install the extension:

```json
"mounts": [
  "type=volume,source=elixir-expert-bin-cache,target=/root/.vscode-server/data/User/globalStorage/expertlsp.expert",
]
```

...so the problem is two-fold: a) the "install_manifest" globalState is being clobbered by other environments (remote SSH, Dev Containers, etc.), and b) in the presence of the "install_manifest" globalState, the extension will never attempt to re-download a stable binary.

This PR makes the following changes:
1. Use a platform specific globalState key (e.g. `"install_manifest:linux_arm64"`).
2. Re-download binaries when they are missing on the filesystem.

The cache remains global (as opposed to workspace-based) but it will be unique per platform, and the file existence check ensures that if the binary is removed for whatever reason (generally because the Dev Container was rebuilt) that it will be reinstalled.

Closes #27