### PR TITLE
feat: support expert's configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,25 @@
           "default": false,
           "markdownDescription": "Install the nightly release of Expert instead of stable releases. Nightly builds contain the latest features but may be less stable."
         },
+        "expert.server.logLevel": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "info",
+            "log"
+          ],
+          "default": "info",
+          "markdownDescription": "Sets the log level for the Expert language server."
+        },
+        "expert.server.workspaceSymbols.minQueryLength": {
+          "scope": "window",
+          "type": "integer",
+          "default": 2,
+          "minimum": 0,
+          "markdownDescription": "Minimum number of characters required to trigger workspace symbol search."
+        },
         "expert.notifyOnServerAutoUpdate": {
           "scope": "window",
           "type": "boolean",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -20,6 +20,23 @@ export function getStartupFlagsOverride() {
 	return getBaseConfig().get<string | undefined>("startupFlagsOverride", undefined);
 }
 
+export function getLogLevel() {
+	return getBaseConfig().get<string>("logLevel", "info");
+}
+
+export function getWorkspaceSymbolsMinQueryLength() {
+	return getBaseConfig().get<number>("workspaceSymbols.minQueryLength", 2);
+}
+
+export function getServerSettings() {
+	return {
+		logLevel: getLogLevel(),
+		workspaceSymbols: {
+			minQueryLength: getWorkspaceSymbolsMinQueryLength(),
+		},
+	};
+}
+
 export function getProjectDirUri(workspace: typeof vsWorkspace): Uri {
 	const projectDirConfig = getBaseConfig().get<string>("projectDir");
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,8 +72,23 @@ export function deactivate() {
 async function start(serverOptions: ServerOptions, workspaceUri: Uri): Promise<LanguageClient> {
 	Logger.info(`Starting Expert in workspace ${workspaceUri?.fsPath}`);
 
+	let lspClient!: LanguageClient;
+
 	const clientOptions: LanguageClientOptions = {
 		outputChannel: Logger.outputChannel(),
+		initializationOptions: Configuration.getServerSettings(),
+		synchronize: {
+			configurationSection: "expert.server",
+		},
+		middleware: {
+			workspace: {
+				didChangeConfiguration: async (_sections, _next) => {
+					await lspClient.sendNotification("workspace/didChangeConfiguration", {
+						settings: Configuration.getServerSettings(),
+					});
+				},
+			},
+		},
 		// Register the server for Elixir documents
 		// the client will iterate through this list and chose the first matching element
 		documentSelector: [
@@ -95,6 +110,7 @@ async function start(serverOptions: ServerOptions, workspaceUri: Uri): Promise<L
 	};
 
 	const client = new LanguageClient("expert", "Expert", serverOptions, clientOptions);
+	lspClient = client;
 
 	try {
 		await client.start();

--- a/src/test/configuration.test.ts
+++ b/src/test/configuration.test.ts
@@ -59,6 +59,45 @@ describe("Configuration", () => {
 		});
 	});
 
+	describe("getLogLevel", () => {
+		it("returns 'info' by default when not configured", () => {
+			assert.strictEqual(Configuration.getLogLevel(), "info");
+		});
+
+		it("returns the configured log level", () => {
+			mockConfigValues.values = { logLevel: "error" };
+			assert.strictEqual(Configuration.getLogLevel(), "error");
+		});
+	});
+
+	describe("getWorkspaceSymbolsMinQueryLength", () => {
+		it("returns 2 by default when not configured", () => {
+			assert.strictEqual(Configuration.getWorkspaceSymbolsMinQueryLength(), 2);
+		});
+
+		it("returns the configured value", () => {
+			mockConfigValues.values = { "workspaceSymbols.minQueryLength": 0 };
+			assert.strictEqual(Configuration.getWorkspaceSymbolsMinQueryLength(), 0);
+		});
+	});
+
+	describe("getServerSettings", () => {
+		it("returns defaults when nothing is configured", () => {
+			assert.deepStrictEqual(Configuration.getServerSettings(), {
+				logLevel: "info",
+				workspaceSymbols: { minQueryLength: 2 },
+			});
+		});
+
+		it("reflects configured values", () => {
+			mockConfigValues.values = { logLevel: "warning", "workspaceSymbols.minQueryLength": 5 };
+			assert.deepStrictEqual(Configuration.getServerSettings(), {
+				logLevel: "warning",
+				workspaceSymbols: { minQueryLength: 5 },
+			});
+		});
+	});
+
 	describe("getAutoInstallUpdateNotification", () => {
 		it("returns true by default when not configured", () => {
 			assert.strictEqual(Configuration.getAutoInstallUpdateNotification(), true);

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -63,6 +63,8 @@ describe("Extension activation with configuration", () => {
 				getServerEnabled: () => configValues.enabled ?? true,
 				getReleasePathOverride: () => configValues.releasePathOverride,
 				getStartupFlagsOverride: () => configValues.startupFlagsOverride,
+				getLogLevel: () => configValues.logLevel ?? "info",
+				getServerSettings: () => ({ logLevel: configValues.logLevel ?? "info" }),
 				getProjectDirUri: () => ({ path: "/test/workspace", fsPath: "/test/workspace" }),
 			},
 		});

--- a/src/test/vscode-mock.mjs
+++ b/src/test/vscode-mock.mjs
@@ -113,5 +113,6 @@ export const workspace = {
 		};
 		return config;
 	},
+	onDidChangeConfiguration: () => ({ dispose: () => {} }),
 	workspaceFolders: [{ uri: { path: "/test/workspace" } }],
 };


### PR DESCRIPTION
Adds support for the expert configuration options, namely `workspaceSymbols.minQueryLength` and `logLevel`