### PR TITLE
feat: add specific support for asdf and mise

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,18 @@
           "type": "string",
           "markdownDescription": "A subdirectory of the current workspace in which to start Expert."
         },
+        "expert.server.versionManager": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "none",
+            "auto",
+            "asdf",
+            "mise"
+          ],
+          "default": "auto",
+          "markdownDescription": "The version manager to use for resolving the runtime. `auto` will detect the version manager automatically, `none` disables version manager integration to use system versions."
+        },
         "expert.server.nightly": {
           "scope": "window",
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
             "mise"
           ],
           "default": "auto",
-          "markdownDescription": "The version manager to use for resolving the runtime. `auto` will detect the version manager automatically, `none` disables version manager integration to use system versions."
+          "markdownDescription": "The version manager to use for resolving the runtime. `auto` will detect the version manager automatically, `none` disables version manager integration to use system versions. Changing this setting requires restarting the extension."
         },
         "expert.server.nightly": {
           "scope": "window",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -57,6 +57,12 @@ export function getAutoInstallUpdateNotification() {
 	return getExpertConfig().get<boolean>("notifyOnServerAutoUpdate", true);
 }
 
+export type VersionManager = "none" | "auto" | "asdf" | "mise";
+
+export function getVersionManager(): VersionManager {
+	return getBaseConfig().get<VersionManager>("versionManager", "auto");
+}
+
 export function getNightly() {
 	return getBaseConfig().get<boolean>("nightly", false);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -178,7 +178,11 @@ async function getServerStartupOptions(
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	const envResult = await resolveEnv(Configuration.getVersionManager(), workspace.workspaceFolders![0], context);
+	const envResult = await resolveEnv(
+		Configuration.getVersionManager(),
+		workspace.workspaceFolders![0],
+		context,
+	);
 
 	if (envResult.detected === "error") {
 		Logger.error(envResult.message);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
-import { commands, ExtensionContext, Uri, window } from "vscode";
+import * as path from "path";
+import { commands, ExtensionContext, Uri, window, workspace } from "vscode";
 import {
 	LanguageClient,
 	LanguageClientOptions,
@@ -11,6 +12,7 @@ import * as Commands from "./commands";
 import * as Configuration from "./configuration";
 import { checkAndInstall, checkForUpdates } from "./installation";
 import * as Logger from "./logger";
+import { type EnvResult, resolveEnv } from "./versionManagers/versionManager";
 
 let client: LanguageClient | undefined;
 
@@ -114,6 +116,27 @@ async function start(serverOptions: ServerOptions): Promise<LanguageClient> {
 	return client;
 }
 
+function buildEnv(envResult: EnvResult): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+
+	if (envResult.detected !== true) {
+		return env;
+	}
+
+	const dirs = [envResult.env.elixirDir, envResult.env.erlangDir].filter(
+		(dir): dir is string => dir !== undefined,
+	);
+	const uniqueDirs = [...new Set(dirs)];
+
+	if (uniqueDirs.length > 0) {
+		const prepend = uniqueDirs.join(path.delimiter);
+		env.PATH = `${prepend}${path.delimiter}${env.PATH ?? ""}`;
+		Logger.info(`Prepending to PATH: ${prepend}`);
+	}
+
+	return env;
+}
+
 function ensureDirectoryExists(directory: Uri) {
 	if (!fs.existsSync(directory.fsPath)) {
 		fs.mkdirSync(directory.fsPath, { recursive: true });
@@ -154,11 +177,22 @@ async function getServerStartupOptions(
 		};
 	}
 
+	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+	const envResult = await resolveEnv(Configuration.getVersionManager(), workspace.workspaceFolders![0], context);
+
+	if (envResult.detected === "error") {
+		Logger.error(envResult.message);
+		window.showErrorMessage(`Expert: ${envResult.message}`);
+		return undefined;
+	}
+
+	const env = buildEnv(envResult);
+
 	const releasePathOverride = Configuration.getReleasePathOverride();
 
 	if (typeof releasePathOverride === "string" && releasePathOverride.length > 0) {
 		Logger.info(`starting language server from release override: "${releasePathOverride}".`);
-		return { command: releasePathOverride, args };
+		return { command: releasePathOverride, args, options: { env } };
 	}
 
 	const languageServerPath = await checkAndInstall(context);
@@ -168,5 +202,5 @@ async function getServerStartupOptions(
 
 	Logger.info(`Expert Language Server:\n${languageServerPath} ${args.join(" ")}`);
 
-	return { command: languageServerPath, args };
+	return { command: languageServerPath, args, options: { env } };
 }

--- a/src/test/configuration.test.ts
+++ b/src/test/configuration.test.ts
@@ -161,27 +161,6 @@ describe("Configuration", () => {
 		});
 	});
 
-	describe("getProjectDirUri", () => {
-		it("returns the workspace URI when project dir is not configured", () => {
-			const workspace = WorkspaceFixture.withUri(Uri.file("/stub"));
-
-			const projectDirUri = Configuration.getProjectDirUri(workspace);
-
-			assert.strictEqual(projectDirUri.fsPath, "/stub");
-			assert.strictEqual(projectDirUri.scheme, "file");
-		});
-
-		it("returns the full directory URI when project dir is configured", () => {
-			const workspace = WorkspaceFixture.withUri(Uri.file("/stub"));
-			mockConfigValues.values = { projectDir: "subdirectory" };
-
-			const projectDirUri = Configuration.getProjectDirUri(workspace);
-
-			assert.strictEqual(projectDirUri.fsPath, "/stub/subdirectory");
-			assert.strictEqual(projectDirUri.scheme, "file");
-		});
-	});
-
 	describe("getVersionManager", () => {
 		it("returns 'auto' by default when not configured", () => {
 			assert.strictEqual(Configuration.getVersionManager(), "auto");
@@ -190,27 +169,6 @@ describe("Configuration", () => {
 		it("returns 'mise' when explicitly set", () => {
 			mockConfigValues.values = { versionManager: "mise" };
 			assert.strictEqual(Configuration.getVersionManager(), "mise");
-		});
-	});
-
-	describe("getProjectDirUri", () => {
-		it("returns the workspace URI when project dir is not configured", () => {
-			const workspace = WorkspaceFixture.withUri(Uri.file("/stub"));
-
-			const projectDirUri = Configuration.getProjectDirUri(workspace);
-
-			assert.strictEqual(projectDirUri.fsPath, "/stub");
-			assert.strictEqual(projectDirUri.scheme, "file");
-		});
-
-		it("returns the full directory URI when project dir is configured", () => {
-			const workspace = WorkspaceFixture.withUri(Uri.file("/stub"));
-			mockConfigValues.values = { projectDir: "subdirectory" };
-
-			const projectDirUri = Configuration.getProjectDirUri(workspace);
-
-			assert.strictEqual(projectDirUri.fsPath, "/stub/subdirectory");
-			assert.strictEqual(projectDirUri.scheme, "file");
 		});
 	});
 });

--- a/src/test/configuration.test.ts
+++ b/src/test/configuration.test.ts
@@ -160,4 +160,57 @@ describe("Configuration", () => {
 			});
 		});
 	});
+
+	describe("getProjectDirUri", () => {
+		it("returns the workspace URI when project dir is not configured", () => {
+			const workspace = WorkspaceFixture.withUri(Uri.file("/stub"));
+
+			const projectDirUri = Configuration.getProjectDirUri(workspace);
+
+			assert.strictEqual(projectDirUri.fsPath, "/stub");
+			assert.strictEqual(projectDirUri.scheme, "file");
+		});
+
+		it("returns the full directory URI when project dir is configured", () => {
+			const workspace = WorkspaceFixture.withUri(Uri.file("/stub"));
+			mockConfigValues.values = { projectDir: "subdirectory" };
+
+			const projectDirUri = Configuration.getProjectDirUri(workspace);
+
+			assert.strictEqual(projectDirUri.fsPath, "/stub/subdirectory");
+			assert.strictEqual(projectDirUri.scheme, "file");
+		});
+	});
+
+	describe("getVersionManager", () => {
+		it("returns 'auto' by default when not configured", () => {
+			assert.strictEqual(Configuration.getVersionManager(), "auto");
+		});
+
+		it("returns 'mise' when explicitly set", () => {
+			mockConfigValues.values = { versionManager: "mise" };
+			assert.strictEqual(Configuration.getVersionManager(), "mise");
+		});
+	});
+
+	describe("getProjectDirUri", () => {
+		it("returns the workspace URI when project dir is not configured", () => {
+			const workspace = WorkspaceFixture.withUri(Uri.file("/stub"));
+
+			const projectDirUri = Configuration.getProjectDirUri(workspace);
+
+			assert.strictEqual(projectDirUri.fsPath, "/stub");
+			assert.strictEqual(projectDirUri.scheme, "file");
+		});
+
+		it("returns the full directory URI when project dir is configured", () => {
+			const workspace = WorkspaceFixture.withUri(Uri.file("/stub"));
+			mockConfigValues.values = { projectDir: "subdirectory" };
+
+			const projectDirUri = Configuration.getProjectDirUri(workspace);
+
+			assert.strictEqual(projectDirUri.fsPath, "/stub/subdirectory");
+			assert.strictEqual(projectDirUri.scheme, "file");
+		});
+	});
 });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -64,7 +64,8 @@ describe("Extension activation with configuration", () => {
 				getReleasePathOverride: () => configValues.releasePathOverride,
 				getStartupFlagsOverride: () => configValues.startupFlagsOverride,
 				getProjectDir: () => configValues.projectDir,
-				getServerSettings: () => ({ projectDir: configValues.projectDir }),
+				getServerSettings: () => ({ logLevel: configValues.logLevel ?? "info", projectDir: configValues.projectDir }),
+				getVersionManager: () => configValues.versionManager ?? "none",
 			},
 		});
 	});

--- a/src/test/versionManager.test.ts
+++ b/src/test/versionManager.test.ts
@@ -1,0 +1,102 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: mocks as any
+
+import assert from "node:assert";
+import { before, describe, it, mock } from "node:test";
+
+let mockMiseDetected = false;
+let mockAsdfDetected = false;
+let mockMiseEnv = {};
+let mockAsdfEnv = {};
+
+describe("resolveEnv", () => {
+	before(async () => {
+		mock.module("../versionManagers/mise", {
+			namedExports: {
+				MiseVersionManager: class {
+					async getEnv() {
+						if (mockMiseDetected) {
+							return { detected: true, env: mockMiseEnv };
+						}
+						return { detected: false };
+					}
+				},
+			},
+		});
+
+		mock.module("../versionManagers/asdf", {
+			namedExports: {
+				AsdfVersionManager: class {
+					async getEnv() {
+						if (mockAsdfDetected) {
+							return { detected: true, env: mockAsdfEnv };
+						}
+						return { detected: false };
+					}
+				},
+			},
+		});
+	});
+
+	const workspaceFolder = { uri: { path: "/test" } } as any;
+	const context = {} as any;
+
+	it("returns not detected when setting is 'none'", async () => {
+		const { resolveEnv } = await import("../versionManagers/versionManager");
+		const result = await resolveEnv("none", workspaceFolder, context);
+
+		assert.deepStrictEqual(result, { detected: false });
+	});
+
+	it("returns detected env when auto-detecting mise", async () => {
+		mockMiseDetected = true;
+		mockMiseEnv = { elixirDir: "/mise/bin", erlangDir: "/mise/bin" };
+
+		const { resolveEnv } = await import("../versionManagers/versionManager");
+		const result = await resolveEnv("auto", workspaceFolder, context);
+
+		assert.strictEqual(result.detected, true);
+		assert.deepStrictEqual((result as any).env, {
+			elixirDir: "/mise/bin",
+			erlangDir: "/mise/bin",
+		});
+
+		mockMiseDetected = false;
+	});
+
+	it("falls back to asdf when mise is not detected in auto mode", async () => {
+		mockMiseDetected = false;
+		mockAsdfDetected = true;
+		mockAsdfEnv = { elixirDir: "/asdf/bin", erlangDir: "/asdf/bin" };
+
+		const { resolveEnv } = await import("../versionManagers/versionManager");
+		const result = await resolveEnv("auto", workspaceFolder, context);
+
+		assert.strictEqual(result.detected, true);
+		assert.deepStrictEqual((result as any).env, {
+			elixirDir: "/asdf/bin",
+			erlangDir: "/asdf/bin",
+		});
+
+		mockAsdfDetected = false;
+	});
+
+	it("returns error when configured manager is not found", async () => {
+		mockMiseDetected = false;
+
+		const { resolveEnv } = await import("../versionManagers/versionManager");
+		const result = await resolveEnv("mise", workspaceFolder, context);
+
+		assert.strictEqual(result.detected, "error");
+		assert.match((result as any).message, /mise/);
+	});
+
+	it("returns not detected when auto finds nothing", async () => {
+		mockMiseDetected = false;
+		mockAsdfDetected = false;
+
+		const { resolveEnv } = await import("../versionManagers/versionManager");
+		const result = await resolveEnv("auto", workspaceFolder, context);
+
+		assert.deepStrictEqual(result, { detected: false });
+	});
+});

--- a/src/versionManagers/asdf.ts
+++ b/src/versionManagers/asdf.ts
@@ -2,87 +2,105 @@
 // Copyright (c) 2021-present Shopify Inc.
 // Licensed under the MIT License: https://opensource.org/licenses/MIT
 
-import { EnvResult, VersionManager } from "./versionManager";
-import * as vscode from "vscode";
-import path from "path";
 import os from "os";
+import path from "path";
+import * as vscode from "vscode";
 import * as Logger from "../logger";
+import { EnvResult, VersionManager } from "./versionManager";
 
 export class AsdfVersionManager extends VersionManager {
-  constructor(workspaceFolder: vscode.WorkspaceFolder, context: vscode.ExtensionContext) {
-    super(workspaceFolder, context);
-  }
+	constructor(workspaceFolder: vscode.WorkspaceFolder, context: vscode.ExtensionContext) {
+		super(workspaceFolder, context);
+	}
 
-  async getEnv(): Promise<EnvResult> {
-    // These directories are where we can find the ASDF executable for v0.16 and above
-    const possibleExecutablePaths = [
-      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "homebrew", "bin"),
-      vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "local", "bin"),
-    ];
+	async getEnv(): Promise<EnvResult> {
+		// These directories are where we can find the ASDF executable for v0.16 and above
+		const possibleExecutablePaths = [
+			vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "homebrew", "bin"),
+			vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "local", "bin"),
+		];
 
-    const asdfInstallation = await this.findAsdfInstallation();
-    const asdfPath = asdfInstallation ?? (await this.findExec(possibleExecutablePaths, "asdf"));
+		const asdfInstallation = await this.findAsdfInstallation();
+		const asdfPath = asdfInstallation ?? (await this.findExec(possibleExecutablePaths, "asdf"));
 
-    // findExec returns the bare name "asdf" when it can't find the executable in any directory.
-    // If we also didn't find a shell script installation, asdf is not detected.
-    if (asdfInstallation === undefined && asdfPath === "asdf") {
-      return { detected: false };
-    }
+		// findExec returns the bare name "asdf" when it can't find the executable in any directory.
+		// If we also didn't find a shell script installation, asdf is not detected.
+		if (asdfInstallation === undefined && asdfPath === "asdf") {
+			return { detected: false };
+		}
 
-    // If there's no extension name, then we are using the ASDF executable directly. If there is an extension, then it's
-    // a shell script and we have to source it first
-    const baseCommand = path.extname(asdfPath) === "" ? asdfPath : `. ${asdfPath} && asdf`;
+		// If there's no extension name, then we are using the ASDF executable directly. If there is an extension, then it's
+		// a shell script and we have to source it first
+		const baseCommand = path.extname(asdfPath) === "" ? asdfPath : `. ${asdfPath} && asdf`;
 
-    const elixirDir = await this.whichDir(baseCommand, "elixir");
-    const erlangDir = await this.whichDir(baseCommand, "erl");
+		const elixirDir = await this.whichDir(baseCommand, "elixir");
+		const erlangDir = await this.whichDir(baseCommand, "erl");
 
-    if (elixirDir === undefined || erlangDir === undefined) {
-      Logger.warn(`Detected asdf but could not find elixir or erlang binaries. Elixir: ${elixirDir}, Erlang: ${erlangDir}`);
-      return { detected: false };
-    }
+		if (elixirDir === undefined || erlangDir === undefined) {
+			Logger.warn(
+				`Detected asdf but could not find elixir or erlang binaries. Elixir: ${elixirDir}, Erlang: ${erlangDir}`,
+			);
+			return { detected: false };
+		}
 
-    return {
-      detected: true,
-      env: { elixirDir, erlangDir },
-    };
-  }
+		return {
+			detected: true,
+			env: { elixirDir, erlangDir },
+		};
+	}
 
-  private async whichDir(baseCommand: string, execName: string): Promise<string | undefined> {
-    try {
-      const { stdout } = await this.runScript(`${baseCommand} which ${execName}`);
-      return path.dirname(stdout.trim());
-    } catch (error: any) {
-      Logger.debug(`asdf which ${execName} failed: ${error.message}`);
-      return undefined;
-    }
-  }
+	private async whichDir(baseCommand: string, execName: string): Promise<string | undefined> {
+		try {
+			const { stdout } = await this.runScript(`${baseCommand} which ${execName}`);
+			return path.dirname(stdout.trim());
+		} catch (error: unknown) {
+			Logger.debug(`asdf which ${execName} failed: ${error}`);
+			return undefined;
+		}
+	}
 
-  // Finds the ASDF installation URI based on what's advertised in the ASDF documentation
-  private async findAsdfInstallation(): Promise<string | undefined> {
-    const scriptName = path.basename(vscode.env.shell) === "fish" ? "asdf.fish" : "asdf.sh";
+	// Finds the ASDF installation URI based on what's advertised in the ASDF documentation
+	private async findAsdfInstallation(): Promise<string | undefined> {
+		const scriptName = path.basename(vscode.env.shell) === "fish" ? "asdf.fish" : "asdf.sh";
 
-    // Possible ASDF installation paths as described in https://asdf-vm.com/guide/getting-started.html#_3-install-asdf.
-    // In order, the methods of installation are:
-    // 1. Git
-    // 2. Pacman
-    // 3. Homebrew M series
-    // 4. Homebrew Intel series
-    const possiblePaths = [
-      vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".asdf", scriptName),
-      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "asdf-vm", scriptName),
-      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "homebrew", "opt", "asdf", "libexec", scriptName),
-      vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "local", "opt", "asdf", "libexec", scriptName),
-    ];
+		// Possible ASDF installation paths as described in https://asdf-vm.com/guide/getting-started.html#_3-install-asdf.
+		// In order, the methods of installation are:
+		// 1. Git
+		// 2. Pacman
+		// 3. Homebrew M series
+		// 4. Homebrew Intel series
+		const possiblePaths = [
+			vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".asdf", scriptName),
+			vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "asdf-vm", scriptName),
+			vscode.Uri.joinPath(
+				vscode.Uri.file("/"),
+				"opt",
+				"homebrew",
+				"opt",
+				"asdf",
+				"libexec",
+				scriptName,
+			),
+			vscode.Uri.joinPath(
+				vscode.Uri.file("/"),
+				"usr",
+				"local",
+				"opt",
+				"asdf",
+				"libexec",
+				scriptName,
+			),
+		];
 
-    for (const possiblePath of possiblePaths) {
-      try {
-        await vscode.workspace.fs.stat(possiblePath);
-        return possiblePath.fsPath;
-      } catch (_error: any) {
-        // Continue looking
-      }
-    }
+		for (const possiblePath of possiblePaths) {
+			try {
+				await vscode.workspace.fs.stat(possiblePath);
+				return possiblePath.fsPath;
+			} catch (_error: unknown) {
+				// Continue looking
+			}
+		}
 
-    return undefined;
-  }
+		return undefined;
+	}
 }

--- a/src/versionManagers/asdf.ts
+++ b/src/versionManagers/asdf.ts
@@ -6,6 +6,7 @@ import { EnvResult, VersionManager } from "./versionManager";
 import * as vscode from "vscode";
 import path from "path";
 import os from "os";
+import * as Logger from "../logger";
 
 export class AsdfVersionManager extends VersionManager {
   constructor(workspaceFolder: vscode.WorkspaceFolder, context: vscode.ExtensionContext) {
@@ -32,16 +33,28 @@ export class AsdfVersionManager extends VersionManager {
     // a shell script and we have to source it first
     const baseCommand = path.extname(asdfPath) === "" ? asdfPath : `. ${asdfPath} && asdf`;
 
-    const {stdout: elixirPath} = await this.runScript(`${baseCommand} which elixir`);
-    const {stdout: erlangPath} = await this.runScript(`${baseCommand} which erlang`);
+    const elixirDir = await this.whichDir(baseCommand, "elixir");
+    const erlangDir = await this.whichDir(baseCommand, "erl");
+
+    if (elixirDir === undefined || erlangDir === undefined) {
+      Logger.warn(`Detected asdf but could not find elixir or erlang binaries. Elixir: ${elixirDir}, Erlang: ${erlangDir}`);
+      return { detected: false };
+    }
 
     return {
       detected: true,
-      env: {
-        elixirPath: elixirPath.trim(),
-        erlangPath: erlangPath.trim(),
-      },
+      env: { elixirDir, erlangDir },
     };
+  }
+
+  private async whichDir(baseCommand: string, execName: string): Promise<string | undefined> {
+    try {
+      const { stdout } = await this.runScript(`${baseCommand} which ${execName}`);
+      return path.dirname(stdout.trim());
+    } catch (error: any) {
+      Logger.debug(`asdf which ${execName} failed: ${error.message}`);
+      return undefined;
+    }
   }
 
   // Finds the ASDF installation URI based on what's advertised in the ASDF documentation

--- a/src/versionManagers/asdf.ts
+++ b/src/versionManagers/asdf.ts
@@ -1,0 +1,75 @@
+// Adapted from https://github.com/Shopify/ruby-lsp/blob/main/vscode/src/ruby/asdf.ts
+// Copyright (c) 2021-present Shopify Inc.
+// Licensed under the MIT License: https://opensource.org/licenses/MIT
+
+import { EnvResult, VersionManager } from "./versionManager";
+import * as vscode from "vscode";
+import path from "path";
+import os from "os";
+
+export class AsdfVersionManager extends VersionManager {
+  constructor(workspaceFolder: vscode.WorkspaceFolder, context: vscode.ExtensionContext) {
+    super(workspaceFolder, context);
+  }
+
+  async getEnv(): Promise<EnvResult> {
+    // These directories are where we can find the ASDF executable for v0.16 and above
+    const possibleExecutablePaths = [
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "homebrew", "bin"),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "local", "bin"),
+    ];
+
+    const asdfInstallation = await this.findAsdfInstallation();
+    const asdfPath = asdfInstallation ?? (await this.findExec(possibleExecutablePaths, "asdf"));
+
+    // findExec returns the bare name "asdf" when it can't find the executable in any directory.
+    // If we also didn't find a shell script installation, asdf is not detected.
+    if (asdfInstallation === undefined && asdfPath === "asdf") {
+      return { detected: false };
+    }
+
+    // If there's no extension name, then we are using the ASDF executable directly. If there is an extension, then it's
+    // a shell script and we have to source it first
+    const baseCommand = path.extname(asdfPath) === "" ? asdfPath : `. ${asdfPath} && asdf`;
+
+    const {stdout: elixirPath} = await this.runScript(`${baseCommand} which elixir`);
+    const {stdout: erlangPath} = await this.runScript(`${baseCommand} which erlang`);
+
+    return {
+      detected: true,
+      env: {
+        elixirPath: elixirPath.trim(),
+        erlangPath: erlangPath.trim(),
+      },
+    };
+  }
+
+  // Finds the ASDF installation URI based on what's advertised in the ASDF documentation
+  private async findAsdfInstallation(): Promise<string | undefined> {
+    const scriptName = path.basename(vscode.env.shell) === "fish" ? "asdf.fish" : "asdf.sh";
+
+    // Possible ASDF installation paths as described in https://asdf-vm.com/guide/getting-started.html#_3-install-asdf.
+    // In order, the methods of installation are:
+    // 1. Git
+    // 2. Pacman
+    // 3. Homebrew M series
+    // 4. Homebrew Intel series
+    const possiblePaths = [
+      vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".asdf", scriptName),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "asdf-vm", scriptName),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "homebrew", "opt", "asdf", "libexec", scriptName),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "local", "opt", "asdf", "libexec", scriptName),
+    ];
+
+    for (const possiblePath of possiblePaths) {
+      try {
+        await vscode.workspace.fs.stat(possiblePath);
+        return possiblePath.fsPath;
+      } catch (_error: any) {
+        // Continue looking
+      }
+    }
+
+    return undefined;
+  }
+}

--- a/src/versionManagers/mise.ts
+++ b/src/versionManagers/mise.ts
@@ -1,6 +1,8 @@
 import { EnvResult, VersionManager } from "./versionManager";
 import * as vscode from "vscode";
+import path from "path";
 import os from "os";
+import * as Logger from "../logger";
 
 export class MiseVersionManager extends VersionManager {
   constructor(workspaceFolder: vscode.WorkspaceFolder, context: vscode.ExtensionContext) {
@@ -14,16 +16,28 @@ export class MiseVersionManager extends VersionManager {
       return { detected: false };
     }
 
-    const {stdout: elixirPath} = await this.runScript(`${misePath} which elixir`);
-    const {stdout: erlangPath} = await this.runScript(`${misePath} which erlang`);
+    const elixirDir = await this.whichDir(misePath, "elixir");
+    const erlangDir = await this.whichDir(misePath, "erl");
+
+    if (elixirDir === undefined || erlangDir === undefined) {
+      Logger.warn(`Detected mise but could not find elixir or erlang binaries. Elixir: ${elixirDir}, Erlang: ${erlangDir}`);
+      return { detected: false };
+    }
 
     return {
       detected: true,
-      env: {
-        elixirPath: elixirPath.trim(),
-        erlangPath: erlangPath.trim(),
-      },
+      env: { elixirDir, erlangDir },
     };
+  }
+
+  private async whichDir(misePath: string, execName: string): Promise<string | undefined> {
+    try {
+      const { stdout } = await this.runScript(`${misePath} which ${execName}`);
+      return path.dirname(stdout.trim());
+    } catch (error: any) {
+      Logger.debug(`mise which ${execName} failed: ${error.message}`);
+      return undefined;
+    }
   }
 
   private async findMiseInstallation(): Promise<string | undefined> {

--- a/src/versionManagers/mise.ts
+++ b/src/versionManagers/mise.ts
@@ -2,69 +2,71 @@
 // Copyright (c) 2021-present Shopify Inc.
 // Licensed under the MIT License: https://opensource.org/licenses/MIT
 
-import { EnvResult, VersionManager } from "./versionManager";
-import * as vscode from "vscode";
-import path from "path";
 import os from "os";
+import path from "path";
+import * as vscode from "vscode";
 import * as Logger from "../logger";
+import { EnvResult, VersionManager } from "./versionManager";
 
 export class MiseVersionManager extends VersionManager {
-  constructor(workspaceFolder: vscode.WorkspaceFolder, context: vscode.ExtensionContext) {
-    super(workspaceFolder, context);
-  }
+	constructor(workspaceFolder: vscode.WorkspaceFolder, context: vscode.ExtensionContext) {
+		super(workspaceFolder, context);
+	}
 
-  async getEnv(): Promise<EnvResult> {
-    const misePath = await this.findMiseInstallation();
+	async getEnv(): Promise<EnvResult> {
+		const misePath = await this.findMiseInstallation();
 
-    if (misePath === undefined) {
-      return { detected: false };
-    }
+		if (misePath === undefined) {
+			return { detected: false };
+		}
 
-    const elixirDir = await this.whichDir(misePath, "elixir");
-    const erlangDir = await this.whichDir(misePath, "erl");
+		const elixirDir = await this.whichDir(misePath, "elixir");
+		const erlangDir = await this.whichDir(misePath, "erl");
 
-    if (elixirDir === undefined || erlangDir === undefined) {
-      Logger.warn(`Detected mise but could not find elixir or erlang binaries. Elixir: ${elixirDir}, Erlang: ${erlangDir}`);
-      return { detected: false };
-    }
+		if (elixirDir === undefined || erlangDir === undefined) {
+			Logger.warn(
+				`Detected mise but could not find elixir or erlang binaries. Elixir: ${elixirDir}, Erlang: ${erlangDir}`,
+			);
+			return { detected: false };
+		}
 
-    return {
-      detected: true,
-      env: { elixirDir, erlangDir },
-    };
-  }
+		return {
+			detected: true,
+			env: { elixirDir, erlangDir },
+		};
+	}
 
-  private async whichDir(misePath: string, execName: string): Promise<string | undefined> {
-    try {
-      const { stdout } = await this.runScript(`${misePath} which ${execName}`);
-      return path.dirname(stdout.trim());
-    } catch (error: any) {
-      Logger.debug(`mise which ${execName} failed: ${error.message}`);
-      return undefined;
-    }
-  }
+	private async whichDir(misePath: string, execName: string): Promise<string | undefined> {
+		try {
+			const { stdout } = await this.runScript(`${misePath} which ${execName}`);
+			return path.dirname(stdout.trim());
+		} catch (error: unknown) {
+			Logger.debug(`mise which ${execName} failed: ${error}`);
+			return undefined;
+		}
+	}
 
-  private async findMiseInstallation(): Promise<string | undefined> {
-    // Possible mise installation paths
-    //
-    // 1. Installation from curl | sh (per mise.jdx.dev Getting Started)
-    // 2. Homebrew M series
-    // 3. Installation from `apt install mise`
-    const possiblePaths = [
-      vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".local", "bin", "mise"),
-      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "homebrew", "bin", "mise"),
-      vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "bin", "mise"),
-    ];
+	private async findMiseInstallation(): Promise<string | undefined> {
+		// Possible mise installation paths
+		//
+		// 1. Installation from curl | sh (per mise.jdx.dev Getting Started)
+		// 2. Homebrew M series
+		// 3. Installation from `apt install mise`
+		const possiblePaths = [
+			vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".local", "bin", "mise"),
+			vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "homebrew", "bin", "mise"),
+			vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "bin", "mise"),
+		];
 
-    for (const possiblePath of possiblePaths) {
-      try {
-        await vscode.workspace.fs.stat(possiblePath);
-        return possiblePath.fsPath;
-      } catch (_error: any) {
-        // Continue looking
-      }
-    }
+		for (const possiblePath of possiblePaths) {
+			try {
+				await vscode.workspace.fs.stat(possiblePath);
+				return possiblePath.fsPath;
+			} catch (_error: unknown) {
+				// Continue looking
+			}
+		}
 
-    return undefined;
-  }
+		return undefined;
+	}
 }

--- a/src/versionManagers/mise.ts
+++ b/src/versionManagers/mise.ts
@@ -1,3 +1,7 @@
+// Adapted from https://github.com/Shopify/ruby-lsp/blob/main/vscode/src/ruby/mise.ts
+// Copyright (c) 2021-present Shopify Inc.
+// Licensed under the MIT License: https://opensource.org/licenses/MIT
+
 import { EnvResult, VersionManager } from "./versionManager";
 import * as vscode from "vscode";
 import path from "path";

--- a/src/versionManagers/mise.ts
+++ b/src/versionManagers/mise.ts
@@ -1,0 +1,52 @@
+import { EnvResult, VersionManager } from "./versionManager";
+import * as vscode from "vscode";
+import os from "os";
+
+export class MiseVersionManager extends VersionManager {
+  constructor(workspaceFolder: vscode.WorkspaceFolder, context: vscode.ExtensionContext) {
+    super(workspaceFolder, context);
+  }
+
+  async getEnv(): Promise<EnvResult> {
+    const misePath = await this.findMiseInstallation();
+
+    if (misePath === undefined) {
+      return { detected: false };
+    }
+
+    const {stdout: elixirPath} = await this.runScript(`${misePath} which elixir`);
+    const {stdout: erlangPath} = await this.runScript(`${misePath} which erlang`);
+
+    return {
+      detected: true,
+      env: {
+        elixirPath: elixirPath.trim(),
+        erlangPath: erlangPath.trim(),
+      },
+    };
+  }
+
+  private async findMiseInstallation(): Promise<string | undefined> {
+    // Possible mise installation paths
+    //
+    // 1. Installation from curl | sh (per mise.jdx.dev Getting Started)
+    // 2. Homebrew M series
+    // 3. Installation from `apt install mise`
+    const possiblePaths = [
+      vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".local", "bin", "mise"),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "homebrew", "bin", "mise"),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "bin", "mise"),
+    ];
+
+    for (const possiblePath of possiblePaths) {
+      try {
+        await vscode.workspace.fs.stat(possiblePath);
+        return possiblePath.fsPath;
+      } catch (_error: any) {
+        // Continue looking
+      }
+    }
+
+    return undefined;
+  }
+}

--- a/src/versionManagers/versionManager.ts
+++ b/src/versionManagers/versionManager.ts
@@ -1,0 +1,71 @@
+// Adapted from https://github.com/Shopify/ruby-lsp/blob/main/vscode/src/ruby/versionManager.ts
+// Copyright (c) 2021-present Shopify Inc.
+// Licensed under the MIT License: https://opensource.org/licenses/MIT
+
+import * as vscode from "vscode";
+import { exec } from "child_process";
+import { promisify } from "util";
+import os from "os";
+import * as Logger from "../logger";
+
+export interface Env {
+  elixirPath: string | undefined;
+  erlangPath: string | undefined;
+}
+
+export type EnvResult =
+  | { detected: false }
+  | { detected: true; env: Env };
+
+export abstract class VersionManager {
+  protected readonly workspaceFolder: vscode.WorkspaceFolder;
+  protected readonly context: vscode.ExtensionContext;
+
+  constructor(workspaceFolder: vscode.WorkspaceFolder, context: vscode.ExtensionContext) {
+    this.workspaceFolder = workspaceFolder;
+    this.context = context;
+  }
+
+  abstract getEnv(): Promise<EnvResult>;
+  // Tries to find `execName` within the given directories. Prefers the executables found in the given directories over
+  // finding the executable in the PATH
+  protected async findExec(directories: vscode.Uri[], execName: string) {
+    for (const uri of directories) {
+      try {
+        const fullUri = vscode.Uri.joinPath(uri, execName);
+        await vscode.workspace.fs.stat(fullUri);
+        Logger.debug(`Found ${execName} executable at ${uri.fsPath}`);
+        return fullUri.fsPath;
+      } catch (_error: any) {
+        // continue searching
+      }
+    }
+
+    return execName;
+  }
+
+  // Runs the given command in the workspace folder, using the user's preferred shell and inheriting the current
+  // process environment
+  protected runScript(command: string) {
+    let shell: string | undefined;
+
+    // If the user has configured a default shell, we use that one since they are probably sourcing their version
+    // manager scripts in that shell's configuration files. On Windows, we never set the shell no matter what to ensure
+    // that activation runs on `cmd.exe` and not PowerShell, which avoids complex quoting and escaping issues.
+    if (vscode.env.shell.length > 0 && os.platform() !== "win32") {
+      shell = vscode.env.shell;
+    }
+
+    Logger.debug(`Running command: \`${command}\` in ${this.workspaceFolder.uri.fsPath} using shell: ${shell}`);
+
+    return this.asyncExec(command, {
+      cwd: this.workspaceFolder.uri.fsPath,
+      shell,
+      env: process.env,
+    });
+  }
+
+  protected async asyncExec(command: string, options: object) {
+    return promisify(exec)(command, options);
+  }
+}

--- a/src/versionManagers/versionManager.ts
+++ b/src/versionManagers/versionManager.ts
@@ -2,112 +2,117 @@
 // Copyright (c) 2021-present Shopify Inc.
 // Licensed under the MIT License: https://opensource.org/licenses/MIT
 
-import * as vscode from "vscode";
 import { exec } from "child_process";
-import { promisify } from "util";
 import os from "os";
+import { promisify } from "util";
+import * as vscode from "vscode";
 import * as Logger from "../logger";
 
 export interface Env {
-  elixirDir: string | undefined;
-  erlangDir: string | undefined;
+	elixirDir: string | undefined;
+	erlangDir: string | undefined;
 }
 
 export type EnvResult =
-  | { detected: false }
-  | { detected: true; env: Env }
-  | { detected: "error"; message: string };
+	| { detected: false }
+	| { detected: true; env: Env }
+	| { detected: "error"; message: string };
 
 export abstract class VersionManager {
-  protected readonly workspaceFolder: vscode.WorkspaceFolder;
-  protected readonly context: vscode.ExtensionContext;
+	protected readonly workspaceFolder: vscode.WorkspaceFolder;
+	protected readonly context: vscode.ExtensionContext;
 
-  constructor(workspaceFolder: vscode.WorkspaceFolder, context: vscode.ExtensionContext) {
-    this.workspaceFolder = workspaceFolder;
-    this.context = context;
-  }
+	constructor(workspaceFolder: vscode.WorkspaceFolder, context: vscode.ExtensionContext) {
+		this.workspaceFolder = workspaceFolder;
+		this.context = context;
+	}
 
-  abstract getEnv(): Promise<EnvResult>;
-  // Tries to find `execName` within the given directories. Prefers the executables found in the given directories over
-  // finding the executable in the PATH
-  protected async findExec(directories: vscode.Uri[], execName: string) {
-    for (const uri of directories) {
-      try {
-        const fullUri = vscode.Uri.joinPath(uri, execName);
-        await vscode.workspace.fs.stat(fullUri);
-        Logger.debug(`Found ${execName} executable at ${uri.fsPath}`);
-        return fullUri.fsPath;
-      } catch (_error: any) {
-        // continue searching
-      }
-    }
+	abstract getEnv(): Promise<EnvResult>;
+	// Tries to find `execName` within the given directories. Prefers the executables found in the given directories over
+	// finding the executable in the PATH
+	protected async findExec(directories: vscode.Uri[], execName: string) {
+		for (const uri of directories) {
+			try {
+				const fullUri = vscode.Uri.joinPath(uri, execName);
+				await vscode.workspace.fs.stat(fullUri);
+				Logger.debug(`Found ${execName} executable at ${uri.fsPath}`);
+				return fullUri.fsPath;
+			} catch (_error: unknown) {
+				// continue searching
+			}
+		}
 
-    return execName;
-  }
+		return execName;
+	}
 
-  // Runs the given command in the workspace folder, using the user's preferred shell and inheriting the current
-  // process environment
-  protected runScript(command: string) {
-    let shell: string | undefined;
+	// Runs the given command in the workspace folder, using the user's preferred shell and inheriting the current
+	// process environment
+	protected runScript(command: string) {
+		let shell: string | undefined;
 
-    // If the user has configured a default shell, we use that one since they are probably sourcing their version
-    // manager scripts in that shell's configuration files. On Windows, we never set the shell no matter what to ensure
-    // that activation runs on `cmd.exe` and not PowerShell, which avoids complex quoting and escaping issues.
-    if (vscode.env.shell.length > 0 && os.platform() !== "win32") {
-      shell = vscode.env.shell;
-    }
+		// If the user has configured a default shell, we use that one since they are probably sourcing their version
+		// manager scripts in that shell's configuration files. On Windows, we never set the shell no matter what to ensure
+		// that activation runs on `cmd.exe` and not PowerShell, which avoids complex quoting and escaping issues.
+		if (vscode.env.shell.length > 0 && os.platform() !== "win32") {
+			shell = vscode.env.shell;
+		}
 
-    Logger.debug(`Running command: \`${command}\` in ${this.workspaceFolder.uri.fsPath} using shell: ${shell}`);
+		Logger.debug(
+			`Running command: \`${command}\` in ${this.workspaceFolder.uri.fsPath} using shell: ${shell}`,
+		);
 
-    return this.asyncExec(command, {
-      cwd: this.workspaceFolder.uri.fsPath,
-      shell,
-      env: process.env,
-    });
-  }
+		return this.asyncExec(command, {
+			cwd: this.workspaceFolder.uri.fsPath,
+			shell,
+			env: process.env,
+		});
+	}
 
-  protected async asyncExec(command: string, options: object) {
-    return promisify(exec)(command, options);
-  }
+	protected async asyncExec(command: string, options: object) {
+		return promisify(exec)(command, options);
+	}
 }
 
 export async function resolveEnv(
-  setting: "none" | "auto" | "asdf" | "mise",
-  workspaceFolder: vscode.WorkspaceFolder,
-  context: vscode.ExtensionContext,
+	setting: "none" | "auto" | "asdf" | "mise",
+	workspaceFolder: vscode.WorkspaceFolder,
+	context: vscode.ExtensionContext,
 ): Promise<EnvResult> {
+	if (setting === "none") {
+		Logger.info("Version manager integration disabled via configuration.");
+		return { detected: false };
+	}
 
-  if (setting === "none") {
-    Logger.info("Version manager integration disabled via configuration.");
-    return { detected: false };
-  }
+	const isAuto = setting === "auto";
 
-  const isAuto = setting === "auto";
+	if (setting === "mise" || isAuto) {
+		const { MiseVersionManager } = await import("./mise");
+		const result = await new MiseVersionManager(workspaceFolder, context).getEnv();
+		if (result.detected) {
+			Logger.info(
+				isAuto ? "Detected version manager: mise" : "Using configured version manager: mise",
+			);
+			return result;
+		}
+		if (!isAuto) {
+			return { detected: "error", message: "Configured version manager 'mise' was not found." };
+		}
+	}
 
-  if (setting === "mise" || isAuto) {
-    const { MiseVersionManager } = await import("./mise");
-    const result = await new MiseVersionManager(workspaceFolder, context).getEnv();
-    if (result.detected) {
-      Logger.info(isAuto ? "Detected version manager: mise" : "Using configured version manager: mise");
-      return result;
-    }
-    if (!isAuto) {
-      return { detected: "error", message: "Configured version manager 'mise' was not found." };
-    }
-  }
+	if (setting === "asdf" || isAuto) {
+		const { AsdfVersionManager } = await import("./asdf");
+		const result = await new AsdfVersionManager(workspaceFolder, context).getEnv();
+		if (result.detected) {
+			Logger.info(
+				isAuto ? "Detected version manager: asdf" : "Using configured version manager: asdf",
+			);
+			return result;
+		}
+		if (!isAuto) {
+			return { detected: "error", message: "Configured version manager 'asdf' was not found." };
+		}
+	}
 
-  if (setting === "asdf" || isAuto) {
-    const { AsdfVersionManager } = await import("./asdf");
-    const result = await new AsdfVersionManager(workspaceFolder, context).getEnv();
-    if (result.detected) {
-      Logger.info(isAuto ? "Detected version manager: asdf" : "Using configured version manager: asdf");
-      return result;
-    }
-    if (!isAuto) {
-      return { detected: "error", message: "Configured version manager 'asdf' was not found." };
-    }
-  }
-
-  Logger.info("No version manager detected, using system environment.");
-  return { detected: false };
+	Logger.info("No version manager detected, using system environment.");
+	return { detected: false };
 }

--- a/src/versionManagers/versionManager.ts
+++ b/src/versionManagers/versionManager.ts
@@ -9,13 +9,14 @@ import os from "os";
 import * as Logger from "../logger";
 
 export interface Env {
-  elixirPath: string | undefined;
-  erlangPath: string | undefined;
+  elixirDir: string | undefined;
+  erlangDir: string | undefined;
 }
 
 export type EnvResult =
   | { detected: false }
-  | { detected: true; env: Env };
+  | { detected: true; env: Env }
+  | { detected: "error"; message: string };
 
 export abstract class VersionManager {
   protected readonly workspaceFolder: vscode.WorkspaceFolder;
@@ -68,4 +69,45 @@ export abstract class VersionManager {
   protected async asyncExec(command: string, options: object) {
     return promisify(exec)(command, options);
   }
+}
+
+export async function resolveEnv(
+  setting: "none" | "auto" | "asdf" | "mise",
+  workspaceFolder: vscode.WorkspaceFolder,
+  context: vscode.ExtensionContext,
+): Promise<EnvResult> {
+
+  if (setting === "none") {
+    Logger.info("Version manager integration disabled via configuration.");
+    return { detected: false };
+  }
+
+  const isAuto = setting === "auto";
+
+  if (setting === "mise" || isAuto) {
+    const { MiseVersionManager } = await import("./mise");
+    const result = await new MiseVersionManager(workspaceFolder, context).getEnv();
+    if (result.detected) {
+      Logger.info(isAuto ? "Detected version manager: mise" : "Using configured version manager: mise");
+      return result;
+    }
+    if (!isAuto) {
+      return { detected: "error", message: "Configured version manager 'mise' was not found." };
+    }
+  }
+
+  if (setting === "asdf" || isAuto) {
+    const { AsdfVersionManager } = await import("./asdf");
+    const result = await new AsdfVersionManager(workspaceFolder, context).getEnv();
+    if (result.detected) {
+      Logger.info(isAuto ? "Detected version manager: asdf" : "Using configured version manager: asdf");
+      return result;
+    }
+    if (!isAuto) {
+      return { detected: "error", message: "Configured version manager 'asdf' was not found." };
+    }
+  }
+
+  Logger.info("No version manager detected, using system environment.");
+  return { detected: false };
 }


### PR DESCRIPTION
This is something we discussed quite a while ago. It adds specific support for asdf and mise, based on the support from Ruby LSP.

It adds a new setting in the config: version manager. It can have values of "none", "auto" (default), "asdf" and "mise". Based on this setting, a version manager is taken or detected, then it is used to look up the Elixir and Erlang binary, and then it prepends directories in which these binaries are to the PATH, to make sure they are taken.

<img width="637" height="179" alt="Screenshot 2026-03-25 at 22 22 37" src="https://github.com/user-attachments/assets/530f8e36-fc67-412c-ab86-f7671f882fc4" />

This most likely only matters on MacOS.

Prepending to the PATH is not ideal, but it's all Expert allows right now. Perhaps in the future Expert could support something lke `EXPERT_ELIXIR_PATH` and `EXPERT_ERLANG_PATH` to simply pass the paths to these binaries directly, not via PATH extension (env vars seems to be only viable way to communicate from VSCode when starting the server, but maybe I'm missing something).

I tested it on MacOS and Linux with mise and I'm looking into options to test it with asdf without breaking my environment. But I would love if others could check it too (@doorgan I think you're using asdf, right?).