### PR TITLE
feat: support fileLogLevel setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,6 +183,19 @@
           "default": "info",
           "markdownDescription": "Sets the log level for the Expert language server."
         },
+        "expert.server.fileLogLevel": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "default",
+            "debug",
+            "info",
+            "warning",
+            "error"
+          ],
+          "default": "default",
+          "markdownDescription": "Sets the file log level for the Expert language server. When set to \"default\", the server's built-in default is used."
+        },
         "expert.server.workspaceSymbols.minQueryLength": {
           "scope": "window",
           "type": "integer",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -24,13 +24,20 @@ export function getLogLevel() {
 	return getBaseConfig().get<string>("logLevel", "info");
 }
 
+export function getFileLogLevel() {
+	return getBaseConfig().get<string>("fileLogLevel", "default");
+}
+
 export function getWorkspaceSymbolsMinQueryLength() {
 	return getBaseConfig().get<number>("workspaceSymbols.minQueryLength", 2);
 }
 
 export function getServerSettings() {
+	const fileLogLevel = getFileLogLevel();
+
 	return {
 		logLevel: getLogLevel(),
+		fileLogLevel: fileLogLevel === "default" ? null : fileLogLevel,
 		workspaceSymbols: {
 			minQueryLength: getWorkspaceSymbolsMinQueryLength(),
 		},

--- a/src/test/configuration.test.ts
+++ b/src/test/configuration.test.ts
@@ -70,6 +70,17 @@ describe("Configuration", () => {
 		});
 	});
 
+	describe("getFileLogLevel", () => {
+		it("returns 'default' by default when not configured", () => {
+			assert.strictEqual(Configuration.getFileLogLevel(), "default");
+		});
+
+		it("returns the configured file log level", () => {
+			mockConfigValues.values = { fileLogLevel: "debug" };
+			assert.strictEqual(Configuration.getFileLogLevel(), "debug");
+		});
+	});
+
 	describe("getWorkspaceSymbolsMinQueryLength", () => {
 		it("returns 2 by default when not configured", () => {
 			assert.strictEqual(Configuration.getWorkspaceSymbolsMinQueryLength(), 2);
@@ -85,14 +96,30 @@ describe("Configuration", () => {
 		it("returns defaults when nothing is configured", () => {
 			assert.deepStrictEqual(Configuration.getServerSettings(), {
 				logLevel: "info",
+				fileLogLevel: null,
 				workspaceSymbols: { minQueryLength: 2 },
 			});
 		});
 
+		it("sends null for fileLogLevel when set to 'default'", () => {
+			mockConfigValues.values = { fileLogLevel: "default" };
+			assert.strictEqual(Configuration.getServerSettings().fileLogLevel, null);
+		});
+
+		it("sends the value for fileLogLevel when set to a non-default value", () => {
+			mockConfigValues.values = { fileLogLevel: "debug" };
+			assert.strictEqual(Configuration.getServerSettings().fileLogLevel, "debug");
+		});
+
 		it("reflects configured values", () => {
-			mockConfigValues.values = { logLevel: "warning", "workspaceSymbols.minQueryLength": 5 };
+			mockConfigValues.values = {
+				logLevel: "warning",
+				fileLogLevel: "error",
+				"workspaceSymbols.minQueryLength": 5,
+			};
 			assert.deepStrictEqual(Configuration.getServerSettings(), {
 				logLevel: "warning",
+				fileLogLevel: "error",
 				workspaceSymbols: { minQueryLength: 5 },
 			});
 		});

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -64,7 +64,11 @@ describe("Extension activation with configuration", () => {
 				getReleasePathOverride: () => configValues.releasePathOverride,
 				getStartupFlagsOverride: () => configValues.startupFlagsOverride,
 				getLogLevel: () => configValues.logLevel ?? "info",
-				getServerSettings: () => ({ logLevel: configValues.logLevel ?? "info" }),
+				getFileLogLevel: () => configValues.fileLogLevel ?? "default",
+				getServerSettings: () => ({
+					logLevel: configValues.logLevel ?? "info",
+					fileLogLevel: null,
+				}),
 				getProjectDirUri: () => ({ path: "/test/workspace", fsPath: "/test/workspace" }),
 			},
 		});


### PR DESCRIPTION
A companion to https://github.com/elixir-lang/expert/pull/563 - allows setting `fileLogLevel` setting, which affects what is logged into `expert.log`.