### PR TITLE
fix: support workspace folders

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,6 +1,4 @@
-import path = require("path");
-
-import { ConfigurationTarget, Uri, workspace as vsWorkspace } from "vscode";
+import { ConfigurationTarget, workspace as vsWorkspace } from "vscode";
 import * as Logger from "./logger";
 
 // wrapped in functions b/c getConfiguration needs to be called late
@@ -32,30 +30,21 @@ export function getWorkspaceSymbolsMinQueryLength() {
 	return getBaseConfig().get<number>("workspaceSymbols.minQueryLength", 2);
 }
 
+export function getProjectDir(): string | undefined {
+	return getBaseConfig().get<string>("projectDir");
+}
+
 export function getServerSettings() {
 	const fileLogLevel = getFileLogLevel();
 
 	return {
 		logLevel: getLogLevel(),
 		fileLogLevel: fileLogLevel === "default" ? null : fileLogLevel,
+		projectDir: getProjectDir(),
 		workspaceSymbols: {
 			minQueryLength: getWorkspaceSymbolsMinQueryLength(),
 		},
 	};
-}
-
-export function getProjectDirUri(workspace: typeof vsWorkspace): Uri {
-	const projectDirConfig = getBaseConfig().get<string>("projectDir");
-
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	const workspacePath = workspace.workspaceFolders![0].uri.path;
-
-	if (typeof projectDirConfig === "string") {
-		const fullDirectoryPath = path.join(workspacePath, projectDirConfig);
-		return Uri.file(fullDirectoryPath);
-	}
-
-	return Uri.file(workspacePath);
 }
 
 export function disableAutoInstallUpdateNotification(): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import { commands, ExtensionContext, Uri, window, workspace } from "vscode";
+import { commands, ExtensionContext, Uri, window } from "vscode";
 import {
 	LanguageClient,
 	LanguageClientOptions,
@@ -39,10 +39,9 @@ export async function activate(context: ExtensionContext): Promise<LanguageClien
 	);
 
 	const serverOptions = await getServerStartupOptions(context);
-	const projectDir = Configuration.getProjectDirUri(workspace);
 
 	if (serverOptions !== undefined) {
-		client = await start(serverOptions, projectDir);
+		client = await start(serverOptions);
 
 		context.subscriptions.push(
 			commands.registerCommand("expert.server.start", () => Commands.start(client!)),
@@ -69,9 +68,7 @@ export function deactivate() {
 	return client.stop();
 }
 
-async function start(serverOptions: ServerOptions, workspaceUri: Uri): Promise<LanguageClient> {
-	Logger.info(`Starting Expert in workspace ${workspaceUri?.fsPath}`);
-
+async function start(serverOptions: ServerOptions): Promise<LanguageClient> {
 	let lspClient!: LanguageClient;
 
 	const clientOptions: LanguageClientOptions = {
@@ -102,11 +99,6 @@ async function start(serverOptions: ServerOptions, workspaceUri: Uri): Promise<L
 			{ language: "phoenix-heex", scheme: "untitled" },
 		],
 		progressOnInitialization: true,
-		workspaceFolder: {
-			index: 0,
-			uri: workspaceUri,
-			name: workspaceUri.path,
-		},
 	};
 
 	const client = new LanguageClient("expert", "Expert", serverOptions, clientOptions);

--- a/src/test/configuration.test.ts
+++ b/src/test/configuration.test.ts
@@ -1,7 +1,5 @@
 import assert from "node:assert";
 import { before, beforeEach, describe, it } from "node:test";
-import { Uri } from "vscode";
-import * as WorkspaceFixture from "./fixtures/workspace-fixture";
 import { mockConfigValues, mockUpdateCalls } from "./vscode-mock.mjs";
 
 type ConfigurationModule = typeof import("../configuration");
@@ -92,11 +90,23 @@ describe("Configuration", () => {
 		});
 	});
 
+	describe("getProjectDir", () => {
+		it("returns undefined by default when not configured", () => {
+			assert.strictEqual(Configuration.getProjectDir(), undefined);
+		});
+
+		it("returns the configured project directory", () => {
+			mockConfigValues.values = { projectDir: "subdirectory" };
+			assert.strictEqual(Configuration.getProjectDir(), "subdirectory");
+		});
+	});
+
 	describe("getServerSettings", () => {
 		it("returns defaults when nothing is configured", () => {
 			assert.deepStrictEqual(Configuration.getServerSettings(), {
 				logLevel: "info",
 				fileLogLevel: null,
+				projectDir: undefined,
 				workspaceSymbols: { minQueryLength: 2 },
 			});
 		});
@@ -115,11 +125,13 @@ describe("Configuration", () => {
 			mockConfigValues.values = {
 				logLevel: "warning",
 				fileLogLevel: "error",
+				projectDir: "apps/my_app",
 				"workspaceSymbols.minQueryLength": 5,
 			};
 			assert.deepStrictEqual(Configuration.getServerSettings(), {
 				logLevel: "warning",
 				fileLogLevel: "error",
+				projectDir: "apps/my_app",
 				workspaceSymbols: { minQueryLength: 5 },
 			});
 		});
@@ -146,27 +158,6 @@ describe("Configuration", () => {
 				value: false,
 				target: 1, // ConfigurationTarget.Global
 			});
-		});
-	});
-
-	describe("getProjectDirUri", () => {
-		it("returns the workspace URI when project dir is not configured", () => {
-			const workspace = WorkspaceFixture.withUri(Uri.file("/stub"));
-
-			const projectDirUri = Configuration.getProjectDirUri(workspace);
-
-			assert.strictEqual(projectDirUri.fsPath, "/stub");
-			assert.strictEqual(projectDirUri.scheme, "file");
-		});
-
-		it("returns the full directory URI when project dir is configured", () => {
-			const workspace = WorkspaceFixture.withUri(Uri.file("/stub"));
-			mockConfigValues.values = { projectDir: "subdirectory" };
-
-			const projectDirUri = Configuration.getProjectDirUri(workspace);
-
-			assert.strictEqual(projectDirUri.fsPath, "/stub/subdirectory");
-			assert.strictEqual(projectDirUri.scheme, "file");
 		});
 	});
 });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -63,13 +63,8 @@ describe("Extension activation with configuration", () => {
 				getServerEnabled: () => configValues.enabled ?? true,
 				getReleasePathOverride: () => configValues.releasePathOverride,
 				getStartupFlagsOverride: () => configValues.startupFlagsOverride,
-				getLogLevel: () => configValues.logLevel ?? "info",
-				getFileLogLevel: () => configValues.fileLogLevel ?? "default",
-				getServerSettings: () => ({
-					logLevel: configValues.logLevel ?? "info",
-					fileLogLevel: null,
-				}),
-				getProjectDirUri: () => ({ path: "/test/workspace", fsPath: "/test/workspace" }),
+				getProjectDir: () => configValues.projectDir,
+				getServerSettings: () => ({ projectDir: configValues.projectDir }),
 			},
 		});
 	});

--- a/src/test/fixtures/workspace-fixture.ts
+++ b/src/test/fixtures/workspace-fixture.ts
@@ -1,7 +1,0 @@
-import type { Uri, workspace as vsWorkspace } from "vscode";
-
-export function withUri(uri: Uri): typeof vsWorkspace {
-	return {
-		workspaceFolders: [{ uri }],
-	} as unknown as typeof vsWorkspace;
-}


### PR DESCRIPTION
We were sending a single project dir on init which forces the lsp into single-folder mode. Expert supports workspace folders(I assume the old code here is a leftover from when lexical didn't support that), so we should stop doing this so vscode switches to workspace folders mode and sends the right folders and notifications