### PR TITLE
test: increase timeout in E2E tests

### DIFF
--- a/src/test-e2e/suite/index.ts
+++ b/src/test-e2e/suite/index.ts
@@ -6,7 +6,7 @@ export async function run(): Promise<void> {
 	const mocha = new Mocha({
 		ui: "bdd",
 		color: true,
-		timeout: 60000,
+		timeout: 120000,
 	});
 
 	const testsRoot = path.resolve(__dirname);


### PR DESCRIPTION
The project takes about 74 seconds to build in the CI. While this perhaps shows something is not right, it's likely a problem with the server, not with the extension, and should be investigated there. Meanwhile IMO there's no point in blocking the pipeline here.