### PR TITLE
feat: setting for Elixir source path

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Tells the extension to use a local release of the Expert language server instead
 
 ### expert.server.elixirSourcePath
 
-Path to a local Elixir source directory; absolute paths are recommended. This is not supported in Expert 0.1.
+Path to a local Elixir source directory; absolute paths are recommended.. When set, go-to-definition on Elixir standard library modules will navigate to source files in this directory instead of returning no result.
 
 ### expert.notifyOnServerAutoUpdate
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Alternatively, you may opt to build Expert from source and point this extension 
 
 Tells the extension to use a local release of the Expert language server instead of the automatically installed one. This path should point to Expert's executable, typically located at `/path/to/expert/apps/expert/burrito_out/expert_darwin_arm64`.
 
+### expert.server.elixirSourcePath
+
+Path to a local Elixir source directory; absolute paths are recommended. This is not supported in Expert 0.1.
 
 ### expert.notifyOnServerAutoUpdate
 

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
         "expert.server.elixirSourcePath": {
           "scope": "window",
           "type": "string",
-          "markdownDescription": "Path to a local Elixir source directory; absolute paths are recommended. Not supported by Expert 0.1"
+          "markdownDescription": "Path to a local Elixir source directory; absolute paths are recommended.. When set, go-to-definition on Elixir standard library modules will navigate to source files in this directory instead of returning no result."
         },
         "expert.server.versionManager": {
           "scope": "window",

--- a/package.json
+++ b/package.json
@@ -165,6 +165,11 @@
           "type": "string",
           "markdownDescription": "A subdirectory of the current workspace in which to start Expert."
         },
+        "expert.server.elixirSourcePath": {
+          "scope": "window",
+          "type": "string",
+          "markdownDescription": "Path to a local Elixir source directory; absolute paths are recommended. Not supported by Expert 0.1"
+        },
         "expert.server.versionManager": {
           "scope": "window",
           "type": "string",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -34,6 +34,10 @@ export function getProjectDir(): string | undefined {
 	return getBaseConfig().get<string>("projectDir");
 }
 
+export function getElixirSourcePath(): string | undefined {
+	return getBaseConfig().get<string>("elixirSourcePath");
+}
+
 export function getServerSettings() {
 	const fileLogLevel = getFileLogLevel();
 
@@ -41,6 +45,7 @@ export function getServerSettings() {
 		logLevel: getLogLevel(),
 		fileLogLevel: fileLogLevel === "default" ? null : fileLogLevel,
 		projectDir: getProjectDir(),
+		elixirSourcePath: getElixirSourcePath(),
 		workspaceSymbols: {
 			minQueryLength: getWorkspaceSymbolsMinQueryLength(),
 		},

--- a/src/test/configuration.test.ts
+++ b/src/test/configuration.test.ts
@@ -101,12 +101,24 @@ describe("Configuration", () => {
 		});
 	});
 
+	describe("getElixirSourcePath", () => {
+		it("returns undefined by default when not configured", () => {
+			assert.strictEqual(Configuration.getElixirSourcePath(), undefined);
+		});
+
+		it("returns the configured Elixir source path", () => {
+			mockConfigValues.values = { elixirSourcePath: "/path/to/elixir" };
+			assert.strictEqual(Configuration.getElixirSourcePath(), "/path/to/elixir");
+		});
+	});
+
 	describe("getServerSettings", () => {
 		it("returns defaults when nothing is configured", () => {
 			assert.deepStrictEqual(Configuration.getServerSettings(), {
 				logLevel: "info",
 				fileLogLevel: null,
 				projectDir: undefined,
+				elixirSourcePath: undefined,
 				workspaceSymbols: { minQueryLength: 2 },
 			});
 		});
@@ -126,12 +138,14 @@ describe("Configuration", () => {
 				logLevel: "warning",
 				fileLogLevel: "error",
 				projectDir: "apps/my_app",
+				elixirSourcePath: "./elixir",
 				"workspaceSymbols.minQueryLength": 5,
 			};
 			assert.deepStrictEqual(Configuration.getServerSettings(), {
 				logLevel: "warning",
 				fileLogLevel: "error",
 				projectDir: "apps/my_app",
+				elixirSourcePath: "./elixir",
 				workspaceSymbols: { minQueryLength: 5 },
 			});
 		});


### PR DESCRIPTION
UI setting to pass `elixirSourcePath` configuration, introduced in https://github.com/expert-lsp/expert/pull/568