### PR TITLE
fix: don't automatically ask for github authentication

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -9,7 +9,7 @@ let currentSession: AuthenticationSession | undefined;
 export async function initialize(): Promise<void> {
 	try {
 		currentSession = await authentication.getSession(GITHUB_AUTH_PROVIDER_ID, GITHUB_AUTH_SCOPES, {
-			createIfNone: false,
+			silent: true,
 		});
 		if (currentSession) {
 			Logger.info(`GitHub authentication initialized for ${currentSession.account.label}`);
@@ -17,6 +17,10 @@ export async function initialize(): Promise<void> {
 	} catch (error) {
 		Logger.warn(`Failed to initialize GitHub authentication: ${error}`);
 	}
+}
+
+export function getAccessToken(): string | undefined {
+	return currentSession?.accessToken;
 }
 
 export async function login(): Promise<boolean> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,6 @@ import {
 	ServerOptions,
 	StreamInfo,
 } from "vscode-languageclient/node";
-import * as Auth from "./auth";
 import * as Commands from "./commands";
 import * as Configuration from "./configuration";
 import { checkAndInstall, checkForUpdates } from "./installation";
@@ -31,8 +30,6 @@ export async function activate(context: ExtensionContext): Promise<LanguageClien
 	}
 
 	ensureDirectoryExists(context.globalStorageUri);
-
-	await Auth.initialize();
 
 	context.subscriptions.push(
 		commands.registerCommand("expert.server.checkForUpdates", () => checkForUpdates(context)),

--- a/src/github.ts
+++ b/src/github.ts
@@ -51,7 +51,7 @@ export const GITHUB_HEADERS = {
 	"X-GitHub-Api-Version": "2022-11-28",
 };
 
-function getHeaders(authToken?: string): Record<string, string> {
+export function getHeaders(authToken?: string): Record<string, string> {
 	const headers: Record<string, string> = { ...GITHUB_HEADERS };
 	if (authToken) {
 		headers.Authorization = `Bearer ${authToken}`;

--- a/src/installation.ts
+++ b/src/installation.ts
@@ -1,13 +1,14 @@
 import { createHash } from "crypto";
 import * as fs from "fs";
 import { ExtensionContext, Uri, window } from "vscode";
+import * as Auth from "./auth";
 import * as Configuration from "./configuration";
 import {
 	Asset,
 	fetchNightlyRelease,
 	fetchStableRelease,
-	GITHUB_HEADERS,
 	Release as GitHubRelease,
+	getHeaders,
 	shouldAutoUpgradeFromRC,
 } from "./github";
 import * as Logger from "./logger";
@@ -43,6 +44,7 @@ export async function checkAndInstall(
 	context: ExtensionContext,
 	attemptCount: number = 0,
 ): Promise<string | undefined> {
+	await Auth.initialize();
 	const nightly = Configuration.getNightly();
 
 	// Delete the legacy manifest key
@@ -111,7 +113,7 @@ async function mustInstallLatest(
 }
 
 async function mustInstallNightly(context: ExtensionContext): Promise<string | undefined> {
-	const nightlyRelease = await fetchNightlyRelease();
+	const nightlyRelease = await fetchNightlyRelease(Auth.getAccessToken());
 
 	const asset = findDistribution(nightlyRelease);
 
@@ -134,7 +136,7 @@ async function mustInstallNightly(context: ExtensionContext): Promise<string | u
 }
 
 async function mustInstallStable(context: ExtensionContext): Promise<string | undefined> {
-	const stableRelease = await fetchStableRelease();
+	const stableRelease = await fetchStableRelease(Auth.getAccessToken());
 
 	if (stableRelease === null) {
 		Logger.info("No stable release found, installing nightly release instead...");
@@ -178,7 +180,7 @@ async function compareAndInstallNightly(
 	manifest: Manifest,
 ): Promise<string | undefined> {
 	Logger.info("Checking for nightly updates...");
-	const nightlyRelease = await fetchNightlyRelease();
+	const nightlyRelease = await fetchNightlyRelease(Auth.getAccessToken());
 	const asset = findDistribution(nightlyRelease);
 
 	if (asset === undefined) {
@@ -248,7 +250,7 @@ async function compareAndInstallStable(
 	manifest: Manifest,
 ): Promise<string | undefined> {
 	Logger.info("Checking for stable updates...");
-	const stableRelease = await fetchStableRelease();
+	const stableRelease = await fetchStableRelease(Auth.getAccessToken());
 
 	if (stableRelease === null) {
 		Logger.info("No stable release found, checking for nightly updates instead...");
@@ -309,7 +311,7 @@ function findDistribution(release: GitHubRelease) {
 async function download(asset: Asset, context: ExtensionContext) {
 	const res: Response = await fetch(asset.url, {
 		headers: {
-			...GITHUB_HEADERS,
+			...getHeaders(Auth.getAccessToken()),
 			Accept: "application/octet-stream",
 		},
 	}).catch((e) => {
@@ -344,7 +346,7 @@ async function download(asset: Asset, context: ExtensionContext) {
 async function fetchChecksumsText(asset: Asset): Promise<string> {
 	const res: Response = await fetch(asset.url, {
 		headers: {
-			...GITHUB_HEADERS,
+			...getHeaders(Auth.getAccessToken()),
 			Accept: "application/octet-stream",
 		},
 	}).catch((e) => {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -3,6 +3,7 @@
 
 import assert from "node:assert";
 import { before, beforeEach, describe, it, mock } from "node:test";
+import { mockAuthentication } from "./vscode-mock.mjs";
 
 // Track calls to key functions
 let checkAndInstallCalled = false;
@@ -64,7 +65,10 @@ describe("Extension activation with configuration", () => {
 				getReleasePathOverride: () => configValues.releasePathOverride,
 				getStartupFlagsOverride: () => configValues.startupFlagsOverride,
 				getProjectDir: () => configValues.projectDir,
-				getServerSettings: () => ({ logLevel: configValues.logLevel ?? "info", projectDir: configValues.projectDir }),
+				getServerSettings: () => ({
+					logLevel: configValues.logLevel ?? "info",
+					projectDir: configValues.projectDir,
+				}),
 				getVersionManager: () => configValues.versionManager ?? "none",
 			},
 		});
@@ -75,6 +79,8 @@ describe("Extension activation with configuration", () => {
 		languageClientCreated = false;
 		languageClientArgs = undefined;
 		languageClientServerOptions = undefined;
+		mockAuthentication.session = undefined;
+		mockAuthentication.calls.length = 0;
 		configValues = {};
 	});
 
@@ -112,6 +118,11 @@ describe("Extension activation with configuration", () => {
 				"checkAndInstall should not be called with override",
 			);
 			assert.strictEqual(languageClientCreated, true, "LanguageClient should be created");
+			assert.strictEqual(
+				mockAuthentication.calls.length,
+				0,
+				"GitHub authentication should not initialize with a release override",
+			);
 		});
 	});
 

--- a/src/test/installation.test.ts
+++ b/src/test/installation.test.ts
@@ -10,7 +10,7 @@ import nock from "nock";
 import { getManifestKey, type Manifest } from "../installation";
 import { getExpectedAssetName } from "../platform";
 import * as GithubFixture from "./fixtures/github-fixture";
-import { mockConfigValues, mockWindowMessages } from "./vscode-mock.mjs";
+import { mockAuthentication, mockConfigValues, mockWindowMessages } from "./vscode-mock.mjs";
 
 const GITHUB_API = "https://api.github.com";
 const CHECKSUMS_ASSET_ID = 319436622;
@@ -74,12 +74,54 @@ describe("checkAndInstall", () => {
 	beforeEach(() => {
 		ctx = createTestContext();
 		nock.cleanAll();
+		mockAuthentication.session = undefined;
+		mockAuthentication.calls.length = 0;
 		mockConfigValues.values["nightly"] = true;
 	});
 
 	afterEach(() => cleanupTestContext(ctx));
 
 	describe("nightly channel", () => {
+		it("authenticates release, checksum, and binary requests", async () => {
+			const expectedAsset = getExpectedAssetName();
+			const oldAsset = Buffer.from("old-binary");
+			const newAsset = Buffer.from("new-binary");
+			const authorization = "Bearer github-token";
+
+			fs.writeFileSync(path.join(ctx.tempDir, expectedAsset), oldAsset);
+			ctx.globalStateStore.set(MANIFEST_KEY, {
+				name: expectedAsset,
+				version: "nightly",
+				asset_timestamp: new Date("2025-11-20T00:00:00Z"),
+				release_timestamp: new Date("2025-11-20T00:00:00Z"),
+			});
+			mockAuthentication.session = {
+				accessToken: "github-token",
+				account: { id: "1", label: "octocat" },
+				id: "session-1",
+				scopes: ["repo"],
+			};
+
+			nock(GITHUB_API)
+				.get("/repos/expert-lsp/expert/releases/tags/nightly")
+				.matchHeader("authorization", authorization)
+				.reply(200, GithubFixture.nightlyRelease("2025-11-22T00:24:06Z"));
+			nock(GITHUB_API)
+				.get(`/repos/expert-lsp/expert/releases/assets/${CHECKSUMS_ASSET_ID}`)
+				.matchHeader("authorization", authorization)
+				.reply(200, checksumsContent(expectedAsset, newAsset));
+			nock(GITHUB_API)
+				.get(/\/repos\/expert-lsp\/expert\/releases\/assets\/\d+/)
+				.matchHeader("authorization", authorization)
+				.reply(200, newAsset);
+
+			const result = await Installation.checkAndInstall(ctx.context as any);
+
+			assert.ok(result);
+			assert.deepStrictEqual(fs.readFileSync(result), newAsset);
+			assert.ok(nock.isDone(), `Unmatched requests: ${nock.pendingMocks().join(", ")}`);
+		});
+
 		it("installs the latest nightly when no prior version exists", async () => {
 			const expectedAsset = getExpectedAssetName();
 			const release = GithubFixture.any();
@@ -131,9 +173,7 @@ describe("checkAndInstall", () => {
 			const newRelease = GithubFixture.nightlyRelease("2025-11-22T00:24:06Z");
 			const newAsset = Buffer.from("new-binary-content");
 
-			nock(GITHUB_API)
-				.get("/repos/expert-lsp/expert/releases/tags/nightly")
-				.reply(200, newRelease);
+			nock(GITHUB_API).get("/repos/expert-lsp/expert/releases/tags/nightly").reply(200, newRelease);
 			nock(GITHUB_API)
 				.get(`/repos/expert-lsp/expert/releases/assets/${CHECKSUMS_ASSET_ID}`)
 				.reply(200, checksumsContent(expectedAsset, newAsset));

--- a/src/test/vscode-mock.d.mts
+++ b/src/test/vscode-mock.d.mts
@@ -1,6 +1,17 @@
 export const mockConfigValues: { values: Record<string, unknown> };
 export const mockUpdateCalls: { calls: Array<{ key: string; value: unknown; target: number }> };
 export const mockWindowMessages: { errors: unknown[][]; info: unknown[][] };
+export const mockAuthentication: {
+	session:
+		| {
+				accessToken: string;
+				account: { id: string; label: string };
+				id: string;
+				scopes: string[];
+		  }
+		| undefined;
+	calls: Array<{ providerId: string; scopes: string[]; options: Record<string, boolean> }>;
+};
 export const ConfigurationTarget: { Global: 1; Workspace: 2; WorkspaceFolder: 3 };
 
 interface MockUri {

--- a/src/test/vscode-mock.mjs
+++ b/src/test/vscode-mock.mjs
@@ -94,6 +94,15 @@ export const commands = {
 	registerCommand: () => ({ dispose: () => {} }),
 };
 
+export const mockAuthentication = { session: undefined, calls: [] };
+
+export const authentication = {
+	getSession: (providerId, scopes, options) => {
+		mockAuthentication.calls.push({ providerId, scopes, options });
+		return Promise.resolve(mockAuthentication.session);
+	},
+};
+
 // Track update calls for assertions
 export const mockUpdateCalls = { calls: [] };
 


### PR DESCRIPTION
Fix #51 

We have two issues that this PR fixes:
- the extension would always ask you to authenticate, using the `silent` option fixes this
- we were not properly passing the authentication token to requests